### PR TITLE
Add version-check workflow to gate plugin changes

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,78 @@
+name: Version check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify version + changelog bump for plugin changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          changed_files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "Changed files:"
+          echo "$changed_files"
+          echo
+
+          # Paths that require a version bump when touched.
+          # Docs-only (README, CONTRIBUTING, CHANGELOG itself, LICENSE, .github/) do not.
+          needs_bump=false
+          while IFS= read -r f; do
+            case "$f" in
+              plugins/athena-notes/agents/*|\
+              plugins/athena-notes/commands/*|\
+              plugins/athena-notes/skills/*|\
+              plugins/athena-notes/AGENTS.md|\
+              plugins/athena-notes/CLAUDE.md|\
+              plugins/athena-notes/.claude-plugin/*|\
+              .claude-plugin/*)
+                needs_bump=true
+                echo "Touches versionable path: $f"
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          if [ "$needs_bump" = false ]; then
+            echo "No versionable paths changed — skipping version-bump check."
+            exit 0
+          fi
+
+          echo
+          echo "Versionable changes detected. Verifying version bump + CHANGELOG entry."
+
+          manifest="plugins/athena-notes/.claude-plugin/plugin.json"
+          base_version=$(git show "$BASE_SHA:$manifest" | jq -r '.version')
+          head_version=$(jq -r '.version' "$manifest")
+
+          echo "Base version: $base_version"
+          echo "Head version: $head_version"
+
+          if [ "$base_version" = "$head_version" ]; then
+            echo "::error file=$manifest::Version unchanged ($head_version). Bump $manifest 'version' field and add a CHANGELOG.md entry."
+            exit 1
+          fi
+
+          # Ensure CHANGELOG.md has a section for the new version.
+          if ! grep -Fq "## [$head_version]" CHANGELOG.md; then
+            echo "::error file=CHANGELOG.md::No '## [$head_version]' section found. Add a CHANGELOG.md entry for version $head_version."
+            exit 1
+          fi
+
+          # Ensure CHANGELOG.md itself changed in this PR.
+          if ! echo "$changed_files" | grep -Fxq "CHANGELOG.md"; then
+            echo "::error file=CHANGELOG.md::CHANGELOG.md was not modified. Add an entry describing the changes in version $head_version."
+            exit 1
+          fi
+
+          echo "OK — $base_version -> $head_version, CHANGELOG updated."


### PR DESCRIPTION
## Summary

Adds `.github/workflows/version-check.yml` — a PR CI check that fails if versionable plugin paths change without a corresponding `plugin.json` version bump **and** matching `CHANGELOG.md` section.

## Why

[PR #5](https://github.com/SnowboardTechie/athena-notes/pull/5) nearly merged a new skill without bumping the version or touching the changelog. This workflow prevents that class of slip going forward.

## What it checks

A PR touching any of these paths must bump `plugins/athena-notes/.claude-plugin/plugin.json#version` **and** add a `## [<version>]` section in `CHANGELOG.md` (and modify `CHANGELOG.md` in the same PR):

- `plugins/athena-notes/agents/`
- `plugins/athena-notes/commands/`
- `plugins/athena-notes/skills/`
- `plugins/athena-notes/AGENTS.md`
- `plugins/athena-notes/CLAUDE.md`
- `plugins/athena-notes/.claude-plugin/`
- `.claude-plugin/` (marketplace metadata)

Docs-only PRs (README, CONTRIBUTING, CHANGELOG, LICENSE, `.github/`) are exempt.

## What it doesn't do

- Doesn't enforce SemVer correctness (MINOR vs. PATCH vs. MAJOR) — that's still a human judgment call. It only enforces that *some* bump happened.
- Doesn't auto-tag releases. If you want that, graduate to [release-please](https://github.com/googleapis/release-please-action) later — this workflow is deliberately minimal.

## Test plan

- [ ] Open a test PR that edits only `README.md` — check passes (docs-exempt).
- [ ] Open a test PR that edits a skill without bumping `plugin.json` — check fails with a clear error pointing at the manifest.
- [ ] Open a test PR that bumps `plugin.json` but doesn't touch `CHANGELOG.md` — check fails with a clear error pointing at the changelog.
- [ ] Open a test PR that does both correctly — check passes.