### PR TITLE
Standardize Markdown link convention + enforce in CI

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-lint-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   trailing-slash-links:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,32 @@
+name: Docs lint
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  trailing-slash-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Flag relative trailing-slash links in Markdown
+        run: |
+          set -euo pipefail
+
+          # Links in this repo should point at a concrete .md file, not a directory.
+          # Trailing-slash directory links render on GitHub but break in Obsidian
+          # preview, some IDEs, and some CI doc tooling.
+          #
+          # Pattern: markdown link ](target/) where target is NOT an external URL,
+          # a mailto:, or a bare fragment anchor.
+          pattern='\]\((?!https?://|mailto:|#)[^)]*/\)'
+
+          if rg --pcre2 --type md -n "$pattern" .; then
+            echo "::error::Found relative trailing-slash Markdown links. Link to the concrete .md file instead (see CONTRIBUTING.md → Docs conventions)."
+            exit 1
+          fi
+
+          echo "OK — no relative trailing-slash links found."

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -3,8 +3,6 @@ name: Docs lint
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 jobs:
   trailing-slash-links:
@@ -16,12 +14,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Links in this repo should point at a concrete .md file, not a directory.
-          # Trailing-slash directory links render on GitHub but break in Obsidian
-          # preview, some IDEs, and some CI doc tooling.
-          #
-          # Pattern: markdown link ](target/) where target is NOT an external URL,
-          # a mailto:, or a bare fragment anchor.
+          # Rule and rationale: CONTRIBUTING.md → Docs conventions.
+          # Pattern matches ](target/) where target is not an external URL,
+          # mailto:, or bare fragment anchor.
           pattern='\]\((?!https?://|mailto:|#)[^)]*/\)'
 
           if rg --pcre2 --type md -n "$pattern" .; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,12 @@ Every agent that needs `{{USER_NAME}}`, `{{TIMEZONE}}`, `{{NOTES_ROOT}}`, `{{WOR
 
 Agent and skill bodies should read cleanly as Markdown instructions even to a human (or to Cursor, Aider, Codex). Frontmatter is Claude-Code-specific, but the prose that follows shouldn't assume a specific runtime.
 
+### Docs conventions
+
+Markdown links to files in this repo point at the actual `.md` file, not the directory. For skills, that's `skills/{name}/SKILL.md`; for agents, `agents/{name}.md`. Trailing-slash directory links (e.g., `skills/foo/`) render on GitHub but break in Obsidian preview, some IDEs, and some CI doc tooling. External URLs (`https://…/`) are exempt and keep their native shape.
+
+A small CI check ([`.github/workflows/docs-lint.yml`](.github/workflows/docs-lint.yml)) enforces the rule.
+
 ### No AI attribution in commits
 
 This project never adds `Co-authored-by: Claude` or similar trailers. You're the author.

--- a/plugins/athena-notes/examples/README.md
+++ b/plugins/athena-notes/examples/README.md
@@ -16,10 +16,10 @@ Personal agents and skills Bryan built on top of Athena Notes. They are **refere
 
 | Skill | Purpose | What to adapt |
 | --- | --- | --- |
-| [catalog-review](skills/catalog-review/) | Review catalog dependency update PRs with TypeSpec/lockfile/audit awareness | Remove if you don't use TypeSpec or catalog-style monorepos. |
-| [manual-merge](skills/manual-merge/) | Guided manual merge workflow for a specific repo layout | Adjust to your branching conventions. |
-| [sprint-deliverable-update](skills/sprint-deliverable-update/) | Draft sprint-update comments on HHS-style deliverable issues | Replace HHS deliverable structure with your own ticket/sprint format. |
-| [weekly-planning](skills/weekly-planning/) | Guided ADHD-friendly weekly planning Q&A using the VOMIT framework (Vent / Obligations / Milestones / Investments / Tethers) against a `second-brain` vault | Replace the VOMIT phases, the hardcoded `~/notes/second-brain/` vault path (edit **both** the SKILL.md body and the Weekly Planning template), and the template itself with your own weekly-review process. |
+| [catalog-review](skills/catalog-review/SKILL.md) | Review catalog dependency update PRs with TypeSpec/lockfile/audit awareness | Remove if you don't use TypeSpec or catalog-style monorepos. |
+| [manual-merge](skills/manual-merge/SKILL.md) | Guided manual merge workflow for a specific repo layout | Adjust to your branching conventions. |
+| [sprint-deliverable-update](skills/sprint-deliverable-update/SKILL.md) | Draft sprint-update comments on HHS-style deliverable issues | Replace HHS deliverable structure with your own ticket/sprint format. |
+| [weekly-planning](skills/weekly-planning/SKILL.md) | Guided ADHD-friendly weekly planning Q&A using the VOMIT framework (Vent / Obligations / Milestones / Investments / Tethers) against a `second-brain` vault | Replace the VOMIT phases, the hardcoded `~/notes/second-brain/` vault path (edit **both** the SKILL.md body and the Weekly Planning template), and the template itself with your own weekly-review process. |
 
 ## How to use an example
 


### PR DESCRIPTION
## Summary

Closes #4.

- **[examples/README.md](plugins/athena-notes/examples/README.md)** — 4 skill-table links switch from `skills/{name}/` to `skills/{name}/SKILL.md`, matching the already-consistent agents table in the same file.
- **[CONTRIBUTING.md](CONTRIBUTING.md)** — new "Docs conventions" subsection: links point at the concrete `.md` file, not the directory. External URLs exempt.
- **[`.github/workflows/docs-lint.yml`](.github/workflows/docs-lint.yml)** — PR-triggered job that greps tracked Markdown for relative trailing-slash links. PCRE2 negative lookahead excludes `http(s)://`, `mailto:`, and bare `#anchors`, so the `Keep a Changelog` link at `plugins/athena-notes/AGENTS.md:133` keeps passing.

Commits:

- `49f825a` Standardize Markdown links to concrete .md files
- `cd6abb7` Add docs-lint workflow to enforce link convention
- `0c6598f` docs-lint: drop push trigger, dedupe rationale

The third commit responds to a simplicity pass: `push: main` was redundant with the PR trigger (and inconsistent with `version-check.yml`, which is PR-only), and the workflow's inline rationale duplicated `CONTRIBUTING.md`. Both trimmed.

## Test plan

- [x] Ran the exact CI pattern (\`rg --pcre2 --type md -n '\]\((?!https?://|mailto:|#)[^)]*/\)'\`) against the post-fix tree → zero matches.
- [x] Temporarily introduced a bad link locally, confirmed linter catches it, reverted.
- [x] Verified PCRE2 correctly excludes the external URL at [AGENTS.md:133](plugins/athena-notes/AGENTS.md:133).
- [x] Confirmed all 4 linked \`SKILL.md\` files exist on disk.
- [x] Confirmed \`ripgrep\` is preinstalled on \`ubuntu-latest\` runners (no install step needed).
- [x] CI (docs-lint + version-check) green on this PR.

## Changelog

- [x] **Exempt** — only touched docs, \`.github/\`, \`LICENSE\`, or \`CHANGELOG.md\` itself.