### PR TITLE
Add frontmatter lint CI for agents and skills (closes #1)

### DIFF
--- a/.github/workflows/frontmatter-lint.yml
+++ b/.github/workflows/frontmatter-lint.yml
@@ -6,14 +6,20 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: frontmatter-lint-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   frontmatter-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Ensure PyYAML
-        run: pip install --quiet pyyaml
-
       - name: Lint agent + skill frontmatter
-        run: python3 scripts/lint-frontmatter.py
+        run: |
+          pip install --quiet pyyaml
+          python3 scripts/lint-frontmatter.py

--- a/.github/workflows/frontmatter-lint.yml
+++ b/.github/workflows/frontmatter-lint.yml
@@ -1,0 +1,19 @@
+name: Frontmatter lint
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  frontmatter-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure PyYAML
+        run: pip install --quiet pyyaml
+
+      - name: Lint agent + skill frontmatter
+        run: python3 scripts/lint-frontmatter.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
-## [0.3.0] — 2026-04-22
+### Added
+- `.github/workflows/frontmatter-lint.yml` and `scripts/lint-frontmatter.py` — CI lint that validates every agent (`name`/`description`/`tools`/`model`) and skill (`name`/`description`) frontmatter block, catches the OpenCode-shape `tools:` list vs. Claude Code comma-separated string, enforces the `model:` enum (`opus`/`sonnet`/`haiku`/`inherit`), and checks that skill references in main-tree agent/skill bodies resolve to real skill directories. Examples tree is validated for frontmatter but not for cross-refs (examples point at user-project skills). Runs on `pull_request` and `push` to `main`. Resolves [#1](https://github.com/SnowboardTechie/athena-notes/issues/1).
+
+### Fixed
+- `ship` skill — removed dangling reference to a `worktrunk` skill that does not exist; surfaced by the new frontmatter-lint workflow on first run.
 
 ### Added
 - `issue-create` skill (`plugins/athena-notes/skills/issue-create/`) and `/issue-create` slash command. Q&A-driven drafting of GitHub/Forgejo issues: detects forge and repo, scans `.github/ISSUE_TEMPLATE/` for field-based templates or falls back to a six-section default structure, asks clarifying questions, writes a draft to `.notes/.agents/drafts/` for review, runs a best-effort dedup check, posts via `gh issue create`, sets the template's `type:` via the GraphQL `updateIssueIssueType` mutation (with per-repo ID cache + verify-and-retry), archives the draft on success, and offers to hand off to `/issue-work`. Addresses [#10](https://github.com/SnowboardTechie/athena-notes/issues/10).

--- a/plugins/athena-notes/skills/ship/SKILL.md
+++ b/plugins/athena-notes/skills/ship/SKILL.md
@@ -7,8 +7,6 @@ description: Wrap up worktree work - push branch, open PR, fill description, rep
 
 Push the current branch, open a PR, and fill the description.
 
-Follows the "Wrapping Up" flow from the `worktrunk` skill. Load it for full details.
-
 ---
 
 ## Quick Reference

--- a/scripts/lint-frontmatter.py
+++ b/scripts/lint-frontmatter.py
@@ -33,16 +33,20 @@ import sys
 
 import yaml
 
-PLUGIN_ROOT = pathlib.Path("plugins/athena-notes")
+# Anchor to repo root via script location so `python3 scripts/lint-frontmatter.py`
+# works from any CWD. Silent "0 files found" passes would be a false-green otherwise.
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+PLUGIN_ROOT = REPO_ROOT / "plugins" / "athena-notes"
+EXAMPLES_ROOT = PLUGIN_ROOT / "examples"
 
 AGENT_DIRS = [
     PLUGIN_ROOT / "agents",
-    PLUGIN_ROOT / "examples" / "agents",
+    EXAMPLES_ROOT / "agents",
 ]
 
 SKILL_DIRS = [
     PLUGIN_ROOT / "skills",
-    PLUGIN_ROOT / "examples" / "skills",
+    EXAMPLES_ROOT / "skills",
 ]
 
 VALID_MODELS = {"opus", "sonnet", "haiku", "inherit"}
@@ -62,10 +66,23 @@ _errors = 0
 def report(path: pathlib.Path, line: int | None, msg: str) -> None:
     global _errors
     _errors += 1
-    loc = f"file={path}"
+    # Annotations need paths relative to repo root, not absolute.
+    try:
+        rel = path.resolve().relative_to(REPO_ROOT)
+    except ValueError:
+        rel = path
+    loc = f"file={rel}"
     if line is not None:
         loc += f",line={line}"
     print(f"::error {loc}::{msg}")
+
+
+def is_example(path: pathlib.Path) -> bool:
+    try:
+        path.resolve().relative_to(EXAMPLES_ROOT)
+        return True
+    except ValueError:
+        return False
 
 
 def parse_frontmatter(path: pathlib.Path) -> tuple[dict | None, str, int]:
@@ -175,31 +192,30 @@ def main() -> int:
             if skill_md.is_file():
                 skill_mds.append(skill_md)
             else:
-                report(sub, None, "Skill directory missing SKILL.md.")
+                report(skill_md, None, "Skill directory missing SKILL.md.")
 
-    examples_root = PLUGIN_ROOT / "examples"
-
-    def is_example(path: pathlib.Path) -> bool:
-        try:
-            path.relative_to(examples_root)
-            return True
-        except ValueError:
-            return False
+    if not agent_paths and not skill_mds:
+        # Misconfigured run — the plugin tree is in this repo, so zero-files means
+        # the anchor broke (e.g., moved PLUGIN_ROOT). Surface it instead of exiting 0.
+        report(PLUGIN_ROOT, None, "No agents or skills discovered — check PLUGIN_ROOT.")
+        return 1
 
     skill_names: set[str] = set()
     skill_bodies: list[tuple[pathlib.Path, str, int]] = []
     for skill_md in skill_mds:
-        name, body, body_start = lint_skill(skill_md)
+        name, body, _body_start = lint_skill(skill_md)
         # Only main-tree skills populate the known-names set — examples can claim
         # any name, and shouldn't let typos masquerade as valid targets.
         if name and not is_example(skill_md):
             skill_names.add(name)
-        skill_bodies.append((skill_md, body, body_start))
+        if body:
+            skill_bodies.append((skill_md, body, _body_start))
 
     agent_bodies: list[tuple[pathlib.Path, str, int]] = []
     for agent in agent_paths:
         _, body, body_start = lint_agent(agent)
-        agent_bodies.append((agent, body, body_start))
+        if body:
+            agent_bodies.append((agent, body, body_start))
 
     for path, body, body_start in agent_bodies + skill_bodies:
         if is_example(path):

--- a/scripts/lint-frontmatter.py
+++ b/scripts/lint-frontmatter.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Lint frontmatter for Athena Notes agents and skills.
+
+Rules:
+  Agents (plugins/athena-notes/agents/*.md, plugins/athena-notes/examples/agents/*.md)
+    - Frontmatter block present, valid YAML mapping.
+    - Required string keys: name, description, tools, model.
+    - name matches ^[a-z][a-z0-9-]*$.
+    - tools is a comma-separated string of capitalized tool names (not a YAML list).
+    - model is one of {opus, sonnet, haiku, inherit}.
+
+  Skills (plugins/athena-notes/skills/*/SKILL.md, plugins/athena-notes/examples/skills/*/SKILL.md)
+    - SKILL.md present in each skill directory.
+    - Frontmatter block present, valid YAML mapping.
+    - Required string keys: name, description.
+    - name matches ^[a-z][a-z0-9-]*$.
+
+  Cross-references (main tree only, excludes examples/)
+    - Backtick-wrapped slugs in agent/skill bodies — when the literal word "skill"
+      or "skills" is adjacent (either form: `<name>` skill  OR  skill: `<name>`) —
+      must resolve to a known skill name.
+    - Examples are meant to be copied into user projects with their own skill sets,
+      so we don't enforce resolution there. Frontmatter is still validated.
+
+Emits GitHub Actions error annotations and exits non-zero on any failure.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+import yaml
+
+PLUGIN_ROOT = pathlib.Path("plugins/athena-notes")
+
+AGENT_DIRS = [
+    PLUGIN_ROOT / "agents",
+    PLUGIN_ROOT / "examples" / "agents",
+]
+
+SKILL_DIRS = [
+    PLUGIN_ROOT / "skills",
+    PLUGIN_ROOT / "examples" / "skills",
+]
+
+VALID_MODELS = {"opus", "sonnet", "haiku", "inherit"}
+SLUG_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+TOOLS_RE = re.compile(r"^[A-Z][A-Za-z0-9, ]*$")
+
+# Two tight patterns for skill references in prose:
+#   A) `<name>` skill   |  `<name>` skills  |  `<name>` skill's
+#   B) skill: `<name>`  |  skills: `<name>`
+# Anything looser catches CLI invocations (`via `gh``, `invoke the `tool` agent`).
+REF_RE_TRAILING = re.compile(r"`([a-z][a-z0-9-]*)`\s+skill(?:s|'s)?\b")
+REF_RE_LEADING = re.compile(r"\bskills?\s*:\s*`([a-z][a-z0-9-]*)`")
+
+_errors = 0
+
+
+def report(path: pathlib.Path, line: int | None, msg: str) -> None:
+    global _errors
+    _errors += 1
+    loc = f"file={path}"
+    if line is not None:
+        loc += f",line={line}"
+    print(f"::error {loc}::{msg}")
+
+
+def parse_frontmatter(path: pathlib.Path) -> tuple[dict | None, str, int]:
+    text = path.read_text()
+    lines = text.split("\n")
+    if not lines or lines[0].strip() != "---":
+        report(path, 1, "Missing frontmatter (file must start with '---').")
+        return None, "", 0
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i
+            break
+    if end is None:
+        report(path, 1, "Unterminated frontmatter (no closing '---').")
+        return None, "", 0
+    try:
+        data = yaml.safe_load("\n".join(lines[1:end]))
+    except yaml.YAMLError as e:
+        report(path, 1, f"Invalid YAML in frontmatter: {e}")
+        return None, "", 0
+    if not isinstance(data, dict):
+        report(path, 1, "Frontmatter must be a YAML mapping.")
+        return None, "", 0
+    body = "\n".join(lines[end + 1 :])
+    return data, body, end + 2
+
+
+def check_string_field(path: pathlib.Path, fm: dict, key: str) -> bool:
+    if key not in fm:
+        report(path, 1, f"Missing required frontmatter key '{key}'.")
+        return False
+    value = fm[key]
+    if not isinstance(value, str):
+        report(
+            path,
+            1,
+            f"Frontmatter key '{key}' must be a string, got {type(value).__name__}."
+            + (" (Did you use a YAML list? Use a comma-separated string instead.)" if key == "tools" else ""),
+        )
+        return False
+    if not value.strip():
+        report(path, 1, f"Frontmatter key '{key}' must be non-empty.")
+        return False
+    return True
+
+
+def lint_agent(path: pathlib.Path) -> tuple[str | None, str, int]:
+    fm, body, body_start = parse_frontmatter(path)
+    if fm is None:
+        return None, "", 0
+    for key in ("name", "description", "tools", "model"):
+        check_string_field(path, fm, key)
+    name = fm.get("name") if isinstance(fm.get("name"), str) else None
+    if name and not SLUG_RE.match(name):
+        report(path, 1, f"'name' must be lowercase-hyphenated (e.g., 'my-agent'), got {name!r}.")
+    tools = fm.get("tools")
+    if isinstance(tools, str) and not TOOLS_RE.match(tools.strip()):
+        report(path, 1, f"'tools' must be a comma-separated string of capitalized tool names, got {tools!r}.")
+    model = fm.get("model")
+    if isinstance(model, str) and model not in VALID_MODELS:
+        report(path, 1, f"'model' must be one of {sorted(VALID_MODELS)}, got {model!r}.")
+    return name, body, body_start
+
+
+def lint_skill(skill_md: pathlib.Path) -> tuple[str | None, str, int]:
+    fm, body, body_start = parse_frontmatter(skill_md)
+    if fm is None:
+        return None, "", 0
+    for key in ("name", "description"):
+        check_string_field(skill_md, fm, key)
+    name = fm.get("name") if isinstance(fm.get("name"), str) else None
+    if name and not SLUG_RE.match(name):
+        report(skill_md, 1, f"'name' must be lowercase-hyphenated, got {name!r}.")
+    return name, body, body_start
+
+
+def check_cross_refs(path: pathlib.Path, body: str, body_start: int, known_skills: set[str]) -> None:
+    for offset, line in enumerate(body.split("\n")):
+        for pattern in (REF_RE_TRAILING, REF_RE_LEADING):
+            for m in pattern.finditer(line):
+                slug = m.group(1)
+                if slug in known_skills:
+                    continue
+                report(
+                    path,
+                    body_start + offset,
+                    f"Reference to `{slug}` does not resolve to a known skill. "
+                    f"Known: {sorted(known_skills)}.",
+                )
+
+
+def main() -> int:
+    agent_paths: list[pathlib.Path] = []
+    for d in AGENT_DIRS:
+        if d.is_dir():
+            agent_paths.extend(sorted(d.glob("*.md")))
+
+    skill_mds: list[pathlib.Path] = []
+    for d in SKILL_DIRS:
+        if not d.is_dir():
+            continue
+        for sub in sorted(d.iterdir()):
+            if not sub.is_dir():
+                continue
+            skill_md = sub / "SKILL.md"
+            if skill_md.is_file():
+                skill_mds.append(skill_md)
+            else:
+                report(sub, None, "Skill directory missing SKILL.md.")
+
+    examples_root = PLUGIN_ROOT / "examples"
+
+    def is_example(path: pathlib.Path) -> bool:
+        try:
+            path.relative_to(examples_root)
+            return True
+        except ValueError:
+            return False
+
+    skill_names: set[str] = set()
+    skill_bodies: list[tuple[pathlib.Path, str, int]] = []
+    for skill_md in skill_mds:
+        name, body, body_start = lint_skill(skill_md)
+        # Only main-tree skills populate the known-names set — examples can claim
+        # any name, and shouldn't let typos masquerade as valid targets.
+        if name and not is_example(skill_md):
+            skill_names.add(name)
+        skill_bodies.append((skill_md, body, body_start))
+
+    agent_bodies: list[tuple[pathlib.Path, str, int]] = []
+    for agent in agent_paths:
+        _, body, body_start = lint_agent(agent)
+        agent_bodies.append((agent, body, body_start))
+
+    for path, body, body_start in agent_bodies + skill_bodies:
+        if is_example(path):
+            continue
+        check_cross_refs(path, body, body_start, skill_names)
+
+    if _errors:
+        print(f"\nfrontmatter-lint: {_errors} error(s).", file=sys.stderr)
+        return 1
+    print(
+        f"frontmatter-lint: OK — {len(agent_paths)} agent(s), {len(skill_mds)} skill(s) validated.",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow and Python script that validate agent and skill frontmatter on every PR and push to `main`. Walks the plugin + examples trees, parses each frontmatter with `PyYAML`, enforces required keys + the `tools:` shape (comma-separated string, not OpenCode-style YAML list) and `model:` enum (`opus`/`sonnet`/`haiku`/`inherit`) on agents, and checks that skill references (`` `<name>` skill `` / `skill: `<name>``) in main-tree bodies resolve to real skill directories. Examples are frontmatter-validated but excluded from cross-ref resolution so example skills can point at user-project skills.

First run surfaced a real dangling `worktrunk` skill reference in `ship/SKILL.md`; removed it as a drive-by. Closes #1.

## Test plan

- [x] Clean tree: `python3 scripts/lint-frontmatter.py` validates 14 agents + 16 skills, exit 0.
- [x] Break `agents/pyre.md` with a YAML-list `tools:` and a removed `model:` — 2 errors, exit 1.
- [x] Break `skills/ship/SKILL.md` by removing `description:` — 1 error, exit 1.
- [x] Set `model: gpt-4` — "must be one of [haiku, inherit, opus, sonnet]" error, exit 1.
- [x] Inject `` See the `bogus-helper` skill for stale-reference testing. `` into an agent body — cross-ref error, exit 1.
- [x] Runs from any CWD (repo root, `scripts/`, `/tmp`) — all green after the `__file__` anchor.
- [x] Self-review (correctness / security / simplicity lenses): 0 critical, 0 major remaining after the hardening commit.

## Changelog

- [x] **Non-release PR** — added a bullet under `## [Unreleased]` in `CHANGELOG.md`.