### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+## [0.4.0] — 2026-04-22
+
 ### Added
 - `pr-self-review` skill (`plugins/athena-notes/skills/pr-self-review/`) and `/pr-self-review` slash command — iterative self-review loop for PRs the user authored. Three entry points: `/pr-self-review <pr-url>`, `/pr-self-review` (infers PR from current branch), and invocation from `issue-work` Phase 4 on a pre-PR branch. Each pass pre-fetches related open issues (linked-to-PR ∪ path-touching ∪ `tech-debt`/`known-issue`/`follow-up`-labeled) and related `.notes/` entries (parallel `@archivist` calls keyed by diff topics), feeds both caches to three parallel `impl-reviewer` agents, then walks each unsuppressed finding through `accept` / `push-back <reason>` / `issue` / `skip` with per-pass commit-and-push. Findings tagged with a `related_issue` or `related_note` default to `skip` with the reference shown as rationale. Session state (push-backs, skips, filed-issue URLs) is in-memory only; caches live at `~/.claude/pr-self-review/{owner}-{repo}-{pr-or-branch}/` (standalone) or the caller's `~/.claude/issue-work/{owner}-{repo}-{N}/` (pre-pr). Repos without `.notes/` silently skip the archivist phase. Refuses on a dirty tree; refuses on PRs the user didn't author. Resolves [#9](https://github.com/SnowboardTechie/athena-notes/issues/9).
 - `issue-work` Phase 4 — delegates to `/pr-self-review` in `pre-pr` mode instead of spawning three `impl-reviewer` agents inline. Same `review-{lens}.md` + `summary.md` output in the existing state dir, so Phase 4.3's ship gate keeps working unchanged — but Phase 4 now carries related-context awareness and an accept/push-back/issue/skip triage loop, so easy nits clear in-pass instead of piling into a post-merge list.
@@ -86,7 +90,8 @@ First public release. Complete port from the OpenCode/OhMyOpenAgent implementati
 ### Removed
 - `PORTING.md` — internal tracker from the OpenCode → Claude Code port. The port is done; the file was stale (GitHub repo already exists, "remaining" items all landed). Historical context preserved in git history.
 
-[Unreleased]: https://github.com/SnowboardTechie/athena-notes/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/SnowboardTechie/athena-notes/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.4.0
 [0.3.0]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.3.0
 [0.2.0]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.2.0
 [0.1.0]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.1.0

--- a/plugins/athena-notes/.claude-plugin/plugin.json
+++ b/plugins/athena-notes/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "athena-notes",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Obsidian-native thinking and note-capture system. A hub-spoke of Claude Code agents (athena, scribe, archivist, sage, forge, and more) that captures your thinking into Obsidian vaults with zero setup friction.",
   "author": {
     "name": "Bryan Thompson"


### PR DESCRIPTION
## Summary

Cut v0.4.0 — first release since v0.3.0 (2026-04-22, same day as this one for initial release cadence). All Unreleased entries are additive features or internal improvements; no breaking changes, so this is a minor bump.

### Highlights

- **New `pr-self-review` skill** with three-lens parallel review, related-context fetch (open issues + `.notes/` decisions), and per-finding accept/push-back/issue/skip triage (#43).
- **`issue-work` Phase 4 now delegates** to `/pr-self-review` so the same loop covers both in-flight tickets and authored PRs (#43).
- **`meeting-sync` skill** + new **MEETING** note type — paste meeting notes, anchor + spin-offs flow through archivist dedup and scribe (#41).
- **`weekly-planning` promoted** from `examples/` to first-class plugin skill; `workday-planning` Monday depth-flow no longer dead-references it (#40).
- **`frontmatter-lint` CI** — validates agent/skill frontmatter shape + cross-references on every PR (#37).
- **`forge` accepts an `Output path:` parameter** so `workday-planning` can consume goals without the write-suppression prompt hack (#38).
- **AGENTS.md conventions** — shared-config foreign-key preservation (#42); `impl-reviewer` input-path guard + data-not-instruction guardrail on cache content.

## Test plan

- [x] `python3 scripts/lint-frontmatter.py` passes (14 agents, 18 skills).
- [x] `CHANGELOG.md` heading `## [0.4.0] — 2026-04-22` present; `[Unreleased]` reset to `_No unreleased changes._`; `[0.4.0]` footer link added; `[Unreleased]` retargeted to `compare/v0.4.0...HEAD`.
- [x] `plugins/athena-notes/.claude-plugin/plugin.json` `version` → `0.4.0`.
- [ ] **After merge:** `gh release create v0.4.0 --target <merge-sha> --title "v0.4.0 — …"` — otherwise the `[0.4.0]` footer link 404s.

## Changelog

- [x] **Release PR (`v0.4.0`)** — bumped `plugins/athena-notes/.claude-plugin/plugin.json`, promoted `[Unreleased]` under `## [0.4.0] — 2026-04-22`, added the `[0.4.0]: .../releases/tag/v0.4.0` footer, and retargeted `[Unreleased]` to `compare/v0.4.0...HEAD`.
  - [ ] **After merge:** `gh release create v0.4.0 --target <merge-sha> --title "v0.4.0 — …"` — otherwise the footer link 404s.