### PR TITLE
Add Projects V2 support to issue-create + release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ _No unreleased changes._
 ## [0.4.1] — 2026-04-23
 
 ### Changed
-- `issue-create` skill — GitHub path now attaches new issues to repo-linked GitHub Projects (V2). Queries `repository.projectsV2` filtered to open projects; zero linked projects skips silently, exactly one linked project auto-attaches, two or more prompts via `AskUserQuestion` single-select with `(none)` available. Uses the repo-scoped graphql query rather than `gh project list --owner X` so org-level boards unrelated to this repo stay out of the prompt. Wires into the existing `gh issue create` invocation via a new `project_flag` array; Forgejo has no Projects equivalent and skips entirely. Draft frontmatter gains a `project:` field for traceability.
+- `issue-create` skill — new issues are now attached to open GitHub Projects linked to the target repo. Auto-attaches when exactly one linked project exists, prompts when more than one, skips silently when none. Forgejo path is unchanged (no Projects equivalent).
 
 ## [0.4.0] — 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 
 _No unreleased changes._
 
+## [0.4.1] — 2026-04-23
+
+### Changed
+- `issue-create` skill — GitHub path now attaches new issues to repo-linked GitHub Projects (V2). Queries `repository.projectsV2` filtered to open projects; zero linked projects skips silently, exactly one linked project auto-attaches, two or more prompts via `AskUserQuestion` single-select with `(none)` available. Uses the repo-scoped graphql query rather than `gh project list --owner X` so org-level boards unrelated to this repo stay out of the prompt. Wires into the existing `gh issue create` invocation via a new `project_flag` array; Forgejo has no Projects equivalent and skips entirely. Draft frontmatter gains a `project:` field for traceability.
+
 ## [0.4.0] — 2026-04-22
 
 ### Added
@@ -90,7 +95,8 @@ First public release. Complete port from the OpenCode/OhMyOpenAgent implementati
 ### Removed
 - `PORTING.md` — internal tracker from the OpenCode → Claude Code port. The port is done; the file was stale (GitHub repo already exists, "remaining" items all landed). Historical context preserved in git history.
 
-[Unreleased]: https://github.com/SnowboardTechie/athena-notes/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/SnowboardTechie/athena-notes/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.4.1
 [0.4.0]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.4.0
 [0.3.0]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.3.0
 [0.2.0]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.2.0

--- a/plugins/athena-notes/.claude-plugin/plugin.json
+++ b/plugins/athena-notes/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "athena-notes",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Obsidian-native thinking and note-capture system. A hub-spoke of Claude Code agents (athena, scribe, archivist, sage, forge, and more) that captures your thinking into Obsidian vaults with zero setup friction.",
   "author": {
     "name": "Bryan Thompson"

--- a/plugins/athena-notes/skills/issue-create/SKILL.md
+++ b/plugins/athena-notes/skills/issue-create/SKILL.md
@@ -214,7 +214,7 @@ gh api graphql -f query='
   --jq '[.data.repository.projectsV2.nodes[] | select(.closed == false) | .title]'
 ```
 
-If the query itself fails (non-zero exit, error in response) — most commonly missing `project` scope or a transient API error — surface the error and ask the user whether to proceed without attaching. Do not silently fall through to the zero-projects branch; that looks identical to "this repo has no linked projects" and quietly drops the attachment.
+If the query itself fails (non-zero exit, error in response) — most commonly missing `project` scope or a transient API error — surface the error and ask: *"The GitHub Projects query failed ({error}). Continue posting without attaching to a project? [yes / stop]"*. Treat silence or any non-`yes` reply as stop. Do not silently fall through to the zero-projects branch; that looks identical to "this repo has no linked projects" and quietly drops the attachment.
 
 Branch on a successful response:
 
@@ -548,7 +548,7 @@ Then ask: "Start working on this now?" If yes, invoke the `issue-work` skill wit
 | Template has `title:` prefix | Pre-fill user's title suggestion with the prefix |
 | Template has required fields | Don't post with empty answers; re-ask |
 | `gh auth status` fails | Stop. Tell user to `gh auth login` |
-| `gh issue create --project` errors on scope | Run `gh auth refresh -s project` then retry — `project` scope is not in the default token |
+| Missing `project` OAuth scope | Run `gh auth refresh -s project` then retry — `project` scope is not in the default token |
 | Forgejo token missing | Stop. Tell user token source (tea config) |
 | No labels / no milestones in repo | Skip the `AskUserQuestion` prompts silently |
 | User edits draft mid-Stage 3 | Re-render from user's edits; continue iteration |

--- a/plugins/athena-notes/skills/issue-create/SKILL.md
+++ b/plugins/athena-notes/skills/issue-create/SKILL.md
@@ -163,7 +163,7 @@ Ask via conversational turns (open-ended answer space). Use the user's initial f
 
 Match answers to template fields by label. If the template has a field that none of the answers cover, ask an additional targeted question. If the template has a field that's already covered by an answer, don't re-ask.
 
-### 2.2 Metadata via `AskUserQuestion`
+### 2.2 Metadata collection
 
 #### Labels
 
@@ -199,17 +199,19 @@ Use `AskUserQuestion` single-select with "(none)" as a default option. On the Fo
 
 Forgejo has no Projects equivalent — skip this subsection entirely on the Forgejo path.
 
-Query Projects **linked to this repo** (not the owner-scoped list, which surfaces boards unrelated to this repo):
+Query Projects **linked to this repo** (not the owner-scoped list, which surfaces boards unrelated to this repo). Pass `owner` / `name` as GraphQL variables rather than inlining them into the query body — matches the variable-binding form used by the issue-type queries in Stage 4.3/4.4:
 
 ```bash
 gh api graphql -f query='
-  query {
-    repository(owner: "'"$owner"'", name: "'"$repo"'") {
+  query($owner: String!, $name: String!) {
+    repository(owner: $owner, name: $name) {
       projectsV2(first: 20) {
-        nodes { number title closed }
+        nodes { title closed }
       }
     }
-  }' --jq '[.data.repository.projectsV2.nodes[] | select(.closed == false) | .title]'
+  }' \
+  -f owner="$owner" -f name="$repo" \
+  --jq '[.data.repository.projectsV2.nodes[] | select(.closed == false) | .title]'
 ```
 
 Branch on the result:
@@ -217,8 +219,6 @@ Branch on the result:
 - **Zero open linked projects** → skip silently. No prompt, no flag.
 - **Exactly one open linked project** → attach it automatically. One linked project is unambiguous, so no prompt. Capture the title for Stage 4.2's `--project` flag.
 - **Two or more open linked projects** → `AskUserQuestion` single-select with each title plus `(none)`. Capture the selection (empty when `(none)`).
-
-`repository.projectsV2` returns the subset linked to this specific repo. `gh project list --owner X` would surface every board the owner has, most of which are unrelated — don't use it here.
 
 ---
 
@@ -526,6 +526,7 @@ Show the user:
 
 Labels: {applied}
 Milestone: {applied or "—"}
+Project: {attached or "—"}
 Type: {set or "—" or "⚠ not set, retry manually"}
 
 Archived draft: {archive path}
@@ -545,6 +546,7 @@ Then ask: "Start working on this now?" If yes, invoke the `issue-work` skill wit
 | Template has `title:` prefix | Pre-fill user's title suggestion with the prefix |
 | Template has required fields | Don't post with empty answers; re-ask |
 | `gh auth status` fails | Stop. Tell user to `gh auth login` |
+| `gh issue create --project` errors on scope | Surface the error and tell user to run `gh auth refresh -s project` and retry — the `project` OAuth scope is separate from the default `gh` token scopes |
 | Forgejo token missing | Stop. Tell user token source (tea config) |
 | No labels / no milestones in repo | Skip the `AskUserQuestion` prompts silently |
 | User edits draft mid-Stage 3 | Re-render from user's edits; continue iteration |

--- a/plugins/athena-notes/skills/issue-create/SKILL.md
+++ b/plugins/athena-notes/skills/issue-create/SKILL.md
@@ -195,6 +195,31 @@ If the list is empty, silently skip.
 
 Use `AskUserQuestion` single-select with "(none)" as a default option. On the Forgejo path, after the user picks a title, look up its `id` from the response above for Stage 4.2's `milestone` payload field.
 
+#### Project (GitHub only)
+
+Forgejo has no Projects equivalent — skip this subsection entirely on the Forgejo path.
+
+Query Projects **linked to this repo** (not the owner-scoped list, which surfaces boards unrelated to this repo):
+
+```bash
+gh api graphql -f query='
+  query {
+    repository(owner: "'"$owner"'", name: "'"$repo"'") {
+      projectsV2(first: 20) {
+        nodes { number title closed }
+      }
+    }
+  }' --jq '[.data.repository.projectsV2.nodes[] | select(.closed == false) | .title]'
+```
+
+Branch on the result:
+
+- **Zero open linked projects** → skip silently. No prompt, no flag.
+- **Exactly one open linked project** → attach it automatically. One linked project is unambiguous, so no prompt. Capture the title for Stage 4.2's `--project` flag.
+- **Two or more open linked projects** → `AskUserQuestion` single-select with each title plus `(none)`. Capture the selection (empty when `(none)`).
+
+`repository.projectsV2` returns the subset linked to this specific repo. `gh project list --owner X` would surface every board the owner has, most of which are unrelated — don't use it here.
+
 ---
 
 ## Stage 3 — Draft & review
@@ -231,6 +256,7 @@ template: {template-filename or "default-structure"}
 title: {chosen title}
 labels: [{selected labels}]
 milestone: {selected milestone or empty}
+project: {selected project or empty}
 type: {template's type: field, or empty}
 created: {iso8601}
 ---
@@ -310,19 +336,23 @@ awk '
 The `--label` flag takes one label name per occurrence. Build the command so each selected label becomes its own `--label`:
 
 ```bash
-# Build --label and --milestone flags as arrays so values with spaces survive.
+# Build --label / --milestone / --project flags as arrays so values with spaces survive.
 label_flags=()
 for l in "${selected_labels[@]}"; do label_flags+=(--label "$l"); done
 
 milestone_flag=()
 [[ -n "$milestone" ]] && milestone_flag=(--milestone "$milestone")
 
+project_flag=()
+[[ -n "$project" ]] && project_flag=(--project "$project")
+
 gh issue create \
   --repo "$owner/$repo" \
   --title "$title" \
   --body-file "$BODY_FILE" \
   "${label_flags[@]}" \
-  "${milestone_flag[@]}"
+  "${milestone_flag[@]}" \
+  "${project_flag[@]}"
 ```
 
 The command prints the new issue URL on success. Capture it.

--- a/plugins/athena-notes/skills/issue-create/SKILL.md
+++ b/plugins/athena-notes/skills/issue-create/SKILL.md
@@ -214,7 +214,7 @@ gh api graphql -f query='
   --jq '[.data.repository.projectsV2.nodes[] | select(.closed == false) | .title]'
 ```
 
-If the query itself fails (non-zero exit, error in response) — most commonly missing `project` scope or a transient API error — surface the error and ask: *"The GitHub Projects query failed ({error}). Continue posting without attaching to a project? [yes / stop]"*. Treat silence or any non-`yes` reply as stop. Do not silently fall through to the zero-projects branch; that looks identical to "this repo has no linked projects" and quietly drops the attachment.
+If the query itself fails (non-zero exit, error in response) — most commonly missing `project` scope or a transient API error — surface the error and ask: *"The GitHub Projects query failed ({error}). If this is a scope error, re-auth with `gh auth refresh -s project` and re-run me. Otherwise, continue posting without attaching to a project? [yes / stop]"*. Treat silence or any non-`yes` reply as stop. Do not silently fall through to the zero-projects branch; that looks identical to "this repo has no linked projects" and quietly drops the attachment.
 
 Branch on a successful response:
 
@@ -548,7 +548,6 @@ Then ask: "Start working on this now?" If yes, invoke the `issue-work` skill wit
 | Template has `title:` prefix | Pre-fill user's title suggestion with the prefix |
 | Template has required fields | Don't post with empty answers; re-ask |
 | `gh auth status` fails | Stop. Tell user to `gh auth login` |
-| Missing `project` OAuth scope | Run `gh auth refresh -s project` then retry — `project` scope is not in the default token |
 | Forgejo token missing | Stop. Tell user token source (tea config) |
 | No labels / no milestones in repo | Skip the `AskUserQuestion` prompts silently |
 | User edits draft mid-Stage 3 | Re-render from user's edits; continue iteration |

--- a/plugins/athena-notes/skills/issue-create/SKILL.md
+++ b/plugins/athena-notes/skills/issue-create/SKILL.md
@@ -214,7 +214,9 @@ gh api graphql -f query='
   --jq '[.data.repository.projectsV2.nodes[] | select(.closed == false) | .title]'
 ```
 
-Branch on the result:
+If the query itself fails (non-zero exit, error in response) — most commonly missing `project` scope or a transient API error — surface the error and ask the user whether to proceed without attaching. Do not silently fall through to the zero-projects branch; that looks identical to "this repo has no linked projects" and quietly drops the attachment.
+
+Branch on a successful response:
 
 - **Zero open linked projects** → skip silently. No prompt, no flag.
 - **Exactly one open linked project** → attach it automatically. One linked project is unambiguous, so no prompt. Capture the title for Stage 4.2's `--project` flag.
@@ -546,7 +548,7 @@ Then ask: "Start working on this now?" If yes, invoke the `issue-work` skill wit
 | Template has `title:` prefix | Pre-fill user's title suggestion with the prefix |
 | Template has required fields | Don't post with empty answers; re-ask |
 | `gh auth status` fails | Stop. Tell user to `gh auth login` |
-| `gh issue create --project` errors on scope | Surface the error and tell user to run `gh auth refresh -s project` and retry — the `project` OAuth scope is separate from the default `gh` token scopes |
+| `gh issue create --project` errors on scope | Run `gh auth refresh -s project` then retry — `project` scope is not in the default token |
 | Forgejo token missing | Stop. Tell user token source (tea config) |
 | No labels / no milestones in repo | Skip the `AskUserQuestion` prompts silently |
 | User edits draft mid-Stage 3 | Re-render from user's edits; continue iteration |


### PR DESCRIPTION
## Summary

- `issue-create` GitHub path now attaches new issues to repo-linked GitHub Projects (V2). Queries `repository.projectsV2` filtered to `closed == false`; zero linked projects skips silently, one linked project auto-attaches, two+ prompts via `AskUserQuestion` single-select with `(none)` available.
- Uses the repo-scoped graphql query rather than `gh project list --owner X` — org-level boards unrelated to this repo stay out of the prompt (verified against `HHS/simpler-grants-protocol`, where the org has 5 Projects but only #17 "Simpler Grants Product & Delivery" is linked to the repo).
- Forgejo has no Projects equivalent — the subsection is skipped entirely on that path.
- Combined release: bumps `plugin.json` → `0.4.1` and promotes `[Unreleased]` under `## [0.4.1] — 2026-04-23`.

## Test plan

- [x] `python3 scripts/lint-frontmatter.py` passes (14 agents, 18 skills).
- [x] `repository.projectsV2` graphql query verified against `SnowboardTechie/athena-notes` (0 nodes — would skip) and `HHS/simpler-grants-protocol` (1 open node, #17 — would auto-attach).
- [x] `CHANGELOG.md` heading `## [0.4.1] — 2026-04-23` present; `[Unreleased]` reset to `_No unreleased changes._`; `[0.4.1]` footer link added; `[Unreleased]` retargeted to `compare/v0.4.1...HEAD`.
- [x] `plugins/athena-notes/.claude-plugin/plugin.json` `version` → `0.4.1`.
- [ ] **After merge:** `gh release create v0.4.1 --target <merge-sha> --title "v0.4.1 — issue-create Projects V2 support"` — otherwise the `[0.4.1]` footer link 404s.

## Changelog

- [x] **Release PR (`v0.4.1`)** — bumped `plugins/athena-notes/.claude-plugin/plugin.json`, promoted `[Unreleased]` under `## [0.4.1] — 2026-04-23`, added the `[0.4.1]: .../releases/tag/v0.4.1` footer, and retargeted `[Unreleased]` to `compare/v0.4.1...HEAD`.
  - [ ] **After merge:** `gh release create v0.4.1 --target <merge-sha> --title "v0.4.1 — issue-create Projects V2 support"` — otherwise the footer link 404s.