### PR TITLE
ship: state WIP scope in preamble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Changed
+- `ship` skill — preamble now states the skill's scope explicitly (WIP draft-PR shipping; self-review and merge-readiness are not its job) and points at `/issue-work` for end-to-end ticket work and `/pr-self-review` for standalone review on an already-shipped branch. The draft-PR default was already encoded in behavior; this surfaces the intent for agents and readers encountering `ship` in isolation.
 
 ## [0.4.1] — 2026-04-23
 

--- a/plugins/athena-notes/skills/ship/SKILL.md
+++ b/plugins/athena-notes/skills/ship/SKILL.md
@@ -7,6 +7,8 @@ description: Wrap up worktree work - push branch, open PR, fill description, rep
 
 Push the current branch, open a PR, and fill the description.
 
+Ships WIP as a draft PR by default — self-review and merge-readiness are not this skill's job. For end-to-end ticket work with self-review baked in, use [`/issue-work`](../issue-work/SKILL.md) instead; for a standalone review pass on a branch already shipped with `/ship`, run [`/pr-self-review`](../pr-self-review/SKILL.md) against the open PR.
+
 ---
 
 ## Quick Reference


### PR DESCRIPTION
## Summary

`/ship`'s preamble now states its scope explicitly: ships WIP as a draft PR; self-review and merge-readiness are not this skill's job. Points at `/issue-work` for end-to-end ticket work and `/pr-self-review` for standalone review on an already-shipped branch.

The draft-PR default was already encoded in the body (`Always open as draft` at SKILL.md:63; `"draft":true` in the Forgejo payload) — this surfaces the intent for agents and readers who encounter `/ship` in isolation, so the `ship` / `issue-work` / `pr-self-review` split is self-documenting rather than tribal knowledge.

## Test plan

- [x] `python3 scripts/lint-frontmatter.py` passes (14 agents, 18 skills).
- [x] Preamble change is prose-only; no behavioral change to push / PR-create / description-fill steps.
- [x] Cross-links resolve: `../issue-work/SKILL.md`, `../pr-self-review/SKILL.md` both exist.

## Changelog

- [x] **Non-release PR** — added a bullet under `## [Unreleased]` in `CHANGELOG.md`.
- [ ] **Release PR (`vX.Y.Z`)** — not this PR.
- [ ] **Exempt** — not this PR; touches a versionable path.