### PR TITLE
issue-create: pre-check suggested labels from Q&A signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 
 ### Changed
 - `ship` skill — preamble now states the skill's scope explicitly (WIP draft-PR shipping; self-review and merge-readiness are not its job) and points at `/issue-work` for end-to-end ticket work and `/pr-self-review` for standalone review on an already-shipped branch. The draft-PR default was already encoded in behavior; this surfaces the intent for agents and readers encountering `ship` in isolation.
+- `issue-create` skill — Stage 2.2 label step now pre-checks suggested labels based on the Stage 2 answers, using name-substring matching (`quick win`/`easy`/`low-hanging`, `docs`/`documentation`, `new-skill`, `feature`/`enhancement`, `bug`, `question`/`help wanted`). Pre-checks still go through `AskUserQuestion` so the user can uncheck any that miss. `good first issue` is explicitly excluded from auto-suggestion because it carries external-discoverability semantics on GitHub.
 
 ## [0.4.1] — 2026-04-23
 

--- a/plugins/athena-notes/skills/issue-create/SKILL.md
+++ b/plugins/athena-notes/skills/issue-create/SKILL.md
@@ -181,6 +181,21 @@ On the Forgejo path, after the user picks label names, map each back to its inte
 
 Use `AskUserQuestion` with `multiSelect: true`. Include a "none" option and a free-text "other" option.
 
+**Pre-check label suggestions based on the Stage 2 answers before presenting the question.** The template's `labels:` field (if any) always pre-checks. On top of that, infer from the draft's content using these signals — they apply to any repo's label set, so match by name substring (case-insensitive):
+
+| Signal from Q&A | Label name contains | Rationale |
+|---|---|---|
+| Scope is one file or a handful of lines; no cross-cutting concerns; no new abstractions; implementation hints fit in a sentence | `quick win`, `easy`, `low-hanging` | Small, self-contained — catch these so they're findable later when you want a focused session |
+| Only changes files under `docs/`, `README`, or `*.md` | `docs`, `documentation` | Pure documentation change |
+| Proposes or adds a new skill (mentions `SKILL.md`, skill directory, new capability) | `new-skill` | Matches this plugin's convention |
+| User-visible new behavior, not a fix | `feature`, `enhancement` | Pick whichever exists; prefer `feature` if both |
+| Existing behavior is broken / regresses | `bug` | Unambiguous |
+| Body needs external input before implementation is scoped | `question`, `help wanted` | Pick `question` if it exists, else `help wanted` |
+
+Do **not** pre-check `good first issue` from a "this is small" signal alone — that label has external discoverability semantics (newcomer search on GitHub) and should only be used when the issue is genuinely suitable for a first-time contributor to the repo. Leave it for the user to add manually.
+
+Pre-checked labels still go through `AskUserQuestion` — the user sees them as checked defaults and can uncheck any that miss.
+
 #### Milestone
 
 ```bash


### PR DESCRIPTION
## Summary

- Teach `issue-create` Stage 2.2 to pre-check label suggestions based on signals from the Stage 2 Q&A answers, so small-scope issues are actually tagged (`quick win`, `easy`, `low-hanging`) instead of going out with whatever the template's `labels:` line carried.
- Explicitly exclude `good first issue` from auto-suggestion — it has external-discoverability semantics on GitHub (newcomer search) distinct from "small scope for me."
- Also adds the `quick win` label to this repo (gold, `#fbca04`) and backfills it on #14 and #30, the two currently-open quick-win candidates.

## Test plan

- [x] Created the `quick win` label on SnowboardTechie/athena-notes
- [x] Applied `quick win` to #14 and #30
- [ ] Next `/issue-create` run on a small-scope idea should pre-check `quick win` in the label prompt

## Changelog

- [x] **Non-release PR** — added a bullet under `## [Unreleased]` in `CHANGELOG.md`.
