### PR TITLE
Release 0.4.2 — fix bare /issue-create and /pr-self-review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.4.2] — 2026-04-23
+
+### Removed
+- `plugins/athena-notes/commands/issue-create.md` and `plugins/athena-notes/commands/pr-self-review.md` — redundant command-file shims that collided with their same-named skills and broke bare-form `/issue-create` and `/pr-self-review`. Both names now resolve via skill auto-registration (bare and `/athena-notes:<name>` forms).
+
 ### Changed
 - `ship` skill — preamble now states the skill's scope explicitly (WIP draft-PR shipping; self-review and merge-readiness are not its job) and points at `/issue-work` for end-to-end ticket work and `/pr-self-review` for standalone review on an already-shipped branch. The draft-PR default was already encoded in behavior; this surfaces the intent for agents and readers encountering `ship` in isolation.
 
@@ -96,7 +101,8 @@ First public release. Complete port from the OpenCode/OhMyOpenAgent implementati
 ### Removed
 - `PORTING.md` — internal tracker from the OpenCode → Claude Code port. The port is done; the file was stale (GitHub repo already exists, "remaining" items all landed). Historical context preserved in git history.
 
-[Unreleased]: https://github.com/SnowboardTechie/athena-notes/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/SnowboardTechie/athena-notes/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.4.2
 [0.4.1]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.4.1
 [0.4.0]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.4.0
 [0.3.0]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.3.0

--- a/plugins/athena-notes/.claude-plugin/plugin.json
+++ b/plugins/athena-notes/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "athena-notes",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Obsidian-native thinking and note-capture system. A hub-spoke of Claude Code agents (athena, scribe, archivist, sage, forge, and more) that captures your thinking into Obsidian vaults with zero setup friction.",
   "author": {
     "name": "Bryan Thompson"

--- a/plugins/athena-notes/commands/issue-create.md
+++ b/plugins/athena-notes/commands/issue-create.md
@@ -1,9 +1,0 @@
----
-description: Draft a GitHub/Forgejo issue from a rough idea via Q&A, then post it. Respects .github/ISSUE_TEMPLATE/ templates (heading fidelity + issue-type), dedup-checks before posting, and optionally hands off to /issue-work after creation.
----
-
-Invoke the `issue-create` skill.
-
-Optional input: a rough description of the idea you want to file. The skill's Stage 2 Q&A will pick up whatever you provide and only ask for what's missing.
-
-Arguments: $ARGUMENTS

--- a/plugins/athena-notes/commands/pr-self-review.md
+++ b/plugins/athena-notes/commands/pr-self-review.md
@@ -1,9 +1,0 @@
----
-description: Iterative self-review loop for PRs you authored. Runs the three-lens parallel review (correctness/security/simplicity), pre-feeds reviewers with related open issues and .notes/ decisions so overlaps surface as defer-able, and triages each finding through accept/push-back/issue/skip. Loops until the diff is clean or you say done.
----
-
-Invoke the `pr-self-review` skill.
-
-Optional input: a PR URL (`https://github.com/{owner}/{repo}/pull/{N}` or the Forgejo equivalent). Without an argument, the skill infers the PR from the current branch via `gh pr view`.
-
-Arguments: $ARGUMENTS


### PR DESCRIPTION
## Summary

- Removes `plugins/athena-notes/commands/issue-create.md` and `plugins/athena-notes/commands/pr-self-review.md`. Both were redundant shims that duplicated same-named skills and appear to block bare-form slash invocation (Claude Code resolves plugin skills as both `/<name>` and `/athena-notes:<name>` automatically; the shims were fighting that).
- Bumps `plugin.json` to `0.4.2`, promotes `[Unreleased]` → `[0.4.2]`, retargets the `[Unreleased]` compare link, adds the `[0.4.2]` footer.
- Retains `commands/athena-setup.md` (full implementation, no matching skill) and `commands/plan-workday.md` (alias to the differently-named `workday-planning` skill) — neither triggers the same-name collision.

## Why this is likely right

Bryan's session logs show 22 "Unknown command: /issue-create" failures across multiple worktrees and repos, and zero successful bare invocations. In contrast, bare forms resolve fine for every skill that ships without a command shim: `/ship`, `/session-review`, `/issue-work`, `/weekly-planning`, `/dependency-triage`. The only skills shipping both a shim and a same-named skill are `issue-create` and `pr-self-review` — exactly the two forms we're fixing. Correlation, not proof, but the minimal fix and the skill-only plugins demonstrate the working baseline.

## Test plan

- [ ] In a fresh session after merge + plugin update, `/issue-create` (bare) resolves and enters Stage 1 Detect.
- [ ] `/athena-notes:issue-create` still works.
- [ ] `/pr-self-review` (bare) resolves without "Unknown command".
- [ ] `/athena-notes:pr-self-review` still works.
- [ ] `/athena-setup` and `/plan-workday` continue to work (retained).
- [ ] `python3 scripts/lint-frontmatter.py` passes.

## Changelog

- [x] **Release PR (`v0.4.2`)** — bumped `plugins/athena-notes/.claude-plugin/plugin.json`, promoted `[Unreleased]` under `## [0.4.2] — 2026-04-23`, added the `[0.4.2]: .../releases/tag/v0.4.2` footer, and retargeted `[Unreleased]` to `compare/v0.4.2...HEAD`.
  - [ ] **After merge:** `gh release create v0.4.2 --target <merge-sha> --title "v0.4.2 — fix bare /issue-create and /pr-self-review"`