### PR TITLE
AGENTS.md: document command-file-vs-skill auto-registration rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Changed
+- `AGENTS.md` — new **Command files vs. skill auto-registration** subsection under Skill Authoring. Codifies when to add a `commands/<name>.md` file alongside a skill (full implementation, differently-named alias) and when not to (same-name shim). Surfaced in [#49](https://github.com/SnowboardTechie/athena-notes/pull/49).
+
 ## [0.4.2] — 2026-04-23
 
 ### Removed

--- a/plugins/athena-notes/AGENTS.md
+++ b/plugins/athena-notes/AGENTS.md
@@ -225,6 +225,20 @@ Pattern: before emitting the final YAML, read the existing file, extract every t
 
 Surfaced in [#39](https://github.com/SnowboardTechie/athena-notes/issues/39) / [#40](https://github.com/SnowboardTechie/athena-notes/pull/40); implemented as `workday-planning/SKILL.md` Bootstrap Flow Step 0.
 
+### Command files vs. skill auto-registration
+
+A plugin skill at `skills/<name>/SKILL.md` is auto-registered as both `/<name>` and `/athena-notes:<name>` by Claude Code — no command file required. Adding a `commands/<name>.md` file with the **same name** as a skill shadows that auto-registration and breaks the bare form (`/<name>` returns "Unknown command"), while the namespaced form keeps working.
+
+Decide by role:
+
+| `commands/<name>.md` role | Same-name skill exists? | Keep the command file? |
+|---|---|---|
+| Full implementation (the command IS the logic) | No | Yes — it's the only surface |
+| Alias to a differently-named skill (e.g., `/plan-workday` → `workday-planning`) | No (different name) | Yes — it's a user-facing shortcut |
+| Shim that just re-invokes a same-named skill | Yes | **No** — delete it; auto-reg handles both forms |
+
+Surfaced in [#49](https://github.com/SnowboardTechie/athena-notes/pull/49) (v0.4.2) after `/issue-create` failed across every worktree despite shipping both a command file and a skill. Removing the shims restored the bare form without regressing the namespaced form.
+
 ---
 
 ## PR Review Comments


### PR DESCRIPTION
## Summary

Adds a **Command files vs. skill auto-registration** subsection under Skill Authoring in `plugins/athena-notes/AGENTS.md`. Codifies the rule discovered while shipping v0.4.2 ([#49](https://github.com/SnowboardTechie/athena-notes/pull/49)): a plugin skill auto-registers as both `/<name>` and `/athena-notes:<name>`, so a `commands/<name>.md` shim with the same name shadows auto-reg and breaks the bare form.

Includes a triage table so the next contributor can decide in one glance whether a new `commands/*.md` is pulling weight or is a redundant shim.

## Test plan

- [x] `python3 scripts/lint-frontmatter.py` passes.
- [x] AGENTS.md still renders — new subsection slots between `Shared config: preserve foreign keys` and the `## PR Review Comments` divider.
- [x] CHANGELOG has an `[Unreleased] → ### Changed` bullet describing the observable change.

## Changelog

- [x] **Non-release PR** — added a bullet under `## [Unreleased]` in `CHANGELOG.md`.