### PR TITLE
Release 0.4.3 — session-review daily-plan loop + command-file rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.4.3] — 2026-04-23
+
 ### Changed
 - `AGENTS.md` — new **Command files vs. skill auto-registration** subsection under Skill Authoring. Codifies when to add a `commands/<name>.md` file alongside a skill (full implementation, differently-named alias) and when not to (same-name shim). Surfaced in [#49](https://github.com/SnowboardTechie/athena-notes/pull/49).
 - `session-review` skill — now scans today's daily plan for tracked items resolved in the session and proposes in-place edits at the approval gate. Resolves [#51](https://github.com/SnowboardTechie/athena-notes/issues/51).
@@ -106,7 +108,8 @@ First public release. Complete port from the OpenCode/OhMyOpenAgent implementati
 ### Removed
 - `PORTING.md` — internal tracker from the OpenCode → Claude Code port. The port is done; the file was stale (GitHub repo already exists, "remaining" items all landed). Historical context preserved in git history.
 
-[Unreleased]: https://github.com/SnowboardTechie/athena-notes/compare/v0.4.2...HEAD
+[Unreleased]: https://github.com/SnowboardTechie/athena-notes/compare/v0.4.3...HEAD
+[0.4.3]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.4.3
 [0.4.2]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.4.2
 [0.4.1]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.4.1
 [0.4.0]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.4.0

--- a/plugins/athena-notes/.claude-plugin/plugin.json
+++ b/plugins/athena-notes/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "athena-notes",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Obsidian-native thinking and note-capture system. A hub-spoke of Claude Code agents (athena, scribe, archivist, sage, forge, and more) that captures your thinking into Obsidian vaults with zero setup friction.",
   "author": {
     "name": "Bryan Thompson"


### PR DESCRIPTION
## Summary

Tag release 0.4.3. Bumps `plugins/athena-notes/.claude-plugin/plugin.json` 0.4.2 → 0.4.3, promotes the two `[Unreleased]` entries under a dated `## [0.4.3] — 2026-04-23` heading, adds the `[0.4.3]` tag footer link, and retargets `[Unreleased]` to `compare/v0.4.3...HEAD`.

### Included since 0.4.2

- `session-review` skill now closes resolved items on today's daily plan — categorization row, Step 1.6 scan (path from identity config), Daily-plan output template, Step 8 direct-Edit write. Resolves [#51](https://github.com/SnowboardTechie/athena-notes/issues/51) via [#53](https://github.com/SnowboardTechie/athena-notes/pull/53).
- `AGENTS.md` — new **Command files vs. skill auto-registration** subsection. Codifies when to add a `commands/<name>.md` file alongside a skill. From [#50](https://github.com/SnowboardTechie/athena-notes/pull/50).

## Test plan

- [x] `plugin.json` version bumped
- [x] `[Unreleased]` promoted to `[0.4.3] — 2026-04-23`
- [x] `[0.4.3]` footer added; `[Unreleased]` retargeted to `compare/v0.4.3...HEAD`
- [ ] **After merge:** `gh release create v0.4.3 --target <merge-sha> --title "v0.4.3 — session-review daily-plan loop"` to avoid the footer link 404ing

## Changelog

- [x] **Release PR (`v0.4.3`)** — bumped `plugins/athena-notes/.claude-plugin/plugin.json`, promoted `[Unreleased]` under `## [0.4.3] — 2026-04-23`, added the `[0.4.3]: .../releases/tag/v0.4.3` footer, and retargeted `[Unreleased]` to `compare/v0.4.3...HEAD`.
  - [ ] **After merge:** `gh release create v0.4.3 --target <merge-sha> --title "v0.4.3 — session-review daily-plan loop"` — otherwise the footer link 404s.