### PR TITLE
workday-planning: Phase 8 persistence receipt (closes #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Changed
+- `workday-planning` skill — Phase 8 now prints a write-receipt line (`✅ Wrote: {path} ({N} bytes)`) as item 1 before the summary; remaining items renumber 1-6 to 2-7. Paired Guardrails bullet makes Phase 7 non-skippable. Resolves [#30](https://github.com/SnowboardTechie/athena-notes/issues/30).
+
 ## [0.4.3] — 2026-04-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 ## [Unreleased]
 
 ### Changed
-- `workday-planning` skill — Phase 8 now opens with a persistence receipt (`✅ Wrote: …` on a fresh write, `⏭️ Kept existing: …` when the user declines to overwrite), so a planning session that skipped Phase 7 catches the omission immediately. Resolves [#30](https://github.com/SnowboardTechie/athena-notes/issues/30).
+- `workday-planning` skill — Phase 8 now opens with a persistence receipt: `✅ Wrote: …` on a fresh write, `⏭️ Kept existing: …` when the user declines to overwrite. Resolves [#30](https://github.com/SnowboardTechie/athena-notes/issues/30).
 
 ## [0.4.3] — 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 ## [Unreleased]
 
 ### Changed
-- `workday-planning` skill — Phase 8 now prints a write-receipt line (`✅ Wrote: {path} ({N} bytes)`) as item 1 before the summary; remaining items renumber 1-6 to 2-7. Paired Guardrails bullet makes Phase 7 non-skippable. Resolves [#30](https://github.com/SnowboardTechie/athena-notes/issues/30).
+- `workday-planning` skill — Phase 8 now opens with a persistence receipt (`✅ Wrote: …` on a fresh write, `⏭️ Kept existing: …` when the user declines to overwrite), so a planning session that skipped Phase 7 catches the omission immediately. Resolves [#30](https://github.com/SnowboardTechie/athena-notes/issues/30).
 
 ## [0.4.3] — 2026-04-23
 

--- a/plugins/athena-notes/skills/workday-planning/SKILL.md
+++ b/plugins/athena-notes/skills/workday-planning/SKILL.md
@@ -340,12 +340,13 @@ Write via the Write tool. If the file already exists (user ran planning twice th
 
 Print in this order:
 
-1. Mode + date header (one line).
-2. Week-prep overlay (Monday only).
-3. Per-project synthesis (Phase 3 blocks).
-4. Forge's daily plan (verbatim from Task return).
-5. Week-wrap overlay (Friday only).
-6. Footer: any `⚠️ Sources unavailable` notes from Phase 2 skips.
+1. `✅ Wrote: {absolute output path} ({N} bytes)` — print this before anything else, as proof-of-persistence. If you cannot print this line truthfully, Phase 7 was skipped; go back and do it.
+2. Mode + date header (one line).
+3. Week-prep overlay (Monday only).
+4. Per-project synthesis (Phase 3 blocks).
+5. Forge's daily plan (verbatim from Task return).
+6. Week-wrap overlay (Friday only).
+7. Footer: any `⚠️ Sources unavailable` notes from Phase 2 skips.
 
 ---
 
@@ -517,4 +518,5 @@ If no TTY / user not present, a source failure should still abort (not silently 
 - Do NOT let forge write its `.notes/.agents/forge/today.md` during this flow — pass `Output path: return-only` in the Task prompt. The workday-planning skill owns the canonical daily-plan file.
 - Do NOT re-run bootstrap if the file exists and has projects, even if sources look thin. Suggest `--edit-sources` instead.
 - Do NOT drop top-level frontmatter keys this skill doesn't own (e.g., `weekly_planning:`). Step 0 of the Bootstrap Flow must preserve them on every run.
-- ALWAYS print the mode and date on the first line of output so the user can see what flow they're in.
+- ALWAYS print the mode and date in the Phase 8 header (immediately after the write-receipt) so the user can see what flow they're in.
+- ALWAYS complete Phase 7 before Phase 8. If forge returns goals and the session feels "done" after presenting them, the file has not yet been written. The first line of Phase 8 output is the receipt that confirms otherwise.

--- a/plugins/athena-notes/skills/workday-planning/SKILL.md
+++ b/plugins/athena-notes/skills/workday-planning/SKILL.md
@@ -340,7 +340,10 @@ Write via the Write tool. If the file already exists (user ran planning twice th
 
 Print in this order:
 
-1. `✅ Wrote: {absolute output path} ({N} bytes)` — print this before anything else, as proof-of-persistence. If you cannot print this line truthfully, Phase 7 was skipped; go back and do it.
+1. Persistence receipt — print before anything else:
+   - If Phase 7 wrote the file: `✅ Wrote: {absolute output path} ({N} bytes)`.
+   - If the user chose **Keep existing** in Phase 7: `⏭️ Kept existing: {absolute output path}`.
+   - If you can print neither truthfully, Phase 7 was skipped; go back and do it.
 2. Mode + date header (one line).
 3. Week-prep overlay (Monday only).
 4. Per-project synthesis (Phase 3 blocks).
@@ -518,5 +521,5 @@ If no TTY / user not present, a source failure should still abort (not silently 
 - Do NOT let forge write its `.notes/.agents/forge/today.md` during this flow — pass `Output path: return-only` in the Task prompt. The workday-planning skill owns the canonical daily-plan file.
 - Do NOT re-run bootstrap if the file exists and has projects, even if sources look thin. Suggest `--edit-sources` instead.
 - Do NOT drop top-level frontmatter keys this skill doesn't own (e.g., `weekly_planning:`). Step 0 of the Bootstrap Flow must preserve them on every run.
-- ALWAYS print the mode and date in the Phase 8 header (immediately after the write-receipt) so the user can see what flow they're in.
-- ALWAYS complete Phase 7 before Phase 8. If forge returns goals and the session feels "done" after presenting them, the file has not yet been written. The first line of Phase 8 output is the receipt that confirms otherwise.
+- ALWAYS print the mode and date header in Phase 8 so the user can see what flow they're in.
+- ALWAYS complete Phase 7 before Phase 8. If forge returns goals and the session feels "done" after presenting them, the file has not yet been written. The first line of Phase 8 output is the persistence receipt that confirms otherwise.


### PR DESCRIPTION
## Summary

Adds a persistence-receipt line as item 1 of `workday-planning` Phase 8 so a silently-skipped Phase 7 file write becomes immediately visible. Observed failure on 2026-04-22: forge returned goals, Phase 8 presented them, no file landed in the vault. The contract already required the write in four places — this is behavior drift, not a missing rule, so the fix is a verifiable output line the user and any self-check can key off of.

- Phase 8 item 1 is a three-branch receipt — `✅ Wrote: {path} ({N} bytes)` on a fresh write, `⏭️ Kept existing: {path}` when the user declines to overwrite, with a self-check sentinel for the skipped-entirely case. Covers Phase 7's two valid outcomes plus the failure mode.
- Remaining Phase 8 items shifted 1–6 → 2–7. Verified no internal references to those numbers exist in the skill.
- Guardrails gain one paired `ALWAYS` bullet asserting Phase 7 must complete before Phase 8. The pre-existing `ALWAYS print the mode and date on the first line of output` bullet is updated — the first line is now the receipt, not the mode+date.

The five open questions the ticket flagged (byte-count usefulness, cross-skill pattern for `weekly-planning` / `session-review`, structural Phase 7 restructure, harness-level enforcement, broader multi-phase audit) remain deferred. They can move to a follow-up issue if wanted.

## Test plan

- [x] `scripts/lint-frontmatter.py` — `OK — 14 agent(s), 18 skill(s) validated.`
- [x] Manual re-read of Phase 7 → Phase 8 → Guardrails flow for coherence after renumber (no cross-refs to Phase 8 item numbers elsewhere in the skill).
- [x] Self-review loop via `/pr-self-review` — 2 passes, one Major correctness finding caught and fixed in-loop (falsifiable receipt under Phase 7's "Keep existing" branch — prompted the three-branch receipt shape above); clean after pass 2.

## Changelog

- [x] **Non-release PR** — added a bullet under `## [Unreleased]` in `CHANGELOG.md`.
- [ ] **Release PR (`vX.Y.Z`)** — bumped `plugins/athena-notes/.claude-plugin/plugin.json`, promoted `[Unreleased]` under `## [X.Y.Z] — YYYY-MM-DD`, added the `[X.Y.Z]: .../releases/tag/vX.Y.Z` footer, and retargeted `[Unreleased]` to `compare/vX.Y.Z...HEAD`.
- [ ] **Exempt** — only touched docs, `.github/`, `LICENSE`, or `CHANGELOG.md` itself.