### PR TITLE
session-review: add collaboration lens for cross-project user-preference signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 
 ### Changed
 - `workday-planning` skill — Phase 8 now opens with a persistence receipt: `✅ Wrote: …` on a fresh write, `⏭️ Kept existing: …` when the user declines to overwrite. Resolves [#30](https://github.com/SnowboardTechie/athena-notes/issues/30).
+- `session-review` skill — Step 1 now scans with two lenses (technical + collaboration); Signal Test Q2 softened to allow cross-project user-collaboration preferences alongside project-specific findings; Categorization Criteria split into vault-routes and memory-routes (harness memory destinations for user-preference / project-motivation / external-system-pointer signal). Hub Capture Triggers in `AGENTS.md` clarified as vault-only — the plugin routes collaboration signal to the harness memory system but doesn't own that destination. Resolves [#13](https://github.com/SnowboardTechie/athena-notes/issues/13).
 
 ## [0.4.3] — 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 
 ### Changed
 - `workday-planning` skill — Phase 8 now opens with a persistence receipt: `✅ Wrote: …` on a fresh write, `⏭️ Kept existing: …` when the user declines to overwrite. Resolves [#30](https://github.com/SnowboardTechie/athena-notes/issues/30).
-- `session-review` skill — Step 1 now scans with two lenses (technical + collaboration); Signal Test Q2 softened to allow cross-project user-collaboration preferences alongside project-specific findings; Categorization Criteria split into vault-routes and memory-routes (harness memory destinations for user-preference / project-motivation / external-system-pointer signal). Hub Capture Triggers in `AGENTS.md` clarified as vault-only — the plugin routes collaboration signal to the harness memory system but doesn't own that destination. Resolves [#13](https://github.com/SnowboardTechie/athena-notes/issues/13).
+- `session-review` skill — adds a collaboration lens that routes cross-project user-preference signal (how the user thinks, project motivation, external-system pointers) to the harness memory system instead of the vault. Resolves [#13](https://github.com/SnowboardTechie/athena-notes/issues/13).
 
 ## [0.4.3] — 2026-04-23
 

--- a/plugins/athena-notes/AGENTS.md
+++ b/plugins/athena-notes/AGENTS.md
@@ -142,6 +142,8 @@ Auto-capture these moments without asking — the point of Athena Notes is low-f
 
 Scribe writes immediately on invocation. No previews, no confirmation prompts.
 
+**Scope.** This table covers *vault-note capture* — durable, project-specific knowledge written into Obsidian by `@scribe`. Cross-project user-collaboration preferences (how the user thinks, anchors, decides) route to the harness memory system (e.g., Claude Code auto-memory), not the vault — see `skills/session-review/SKILL.md` for the collaboration-lens flow. The plugin owns the router (recognizing the signal), not the memory destination.
+
 ---
 
 ## Git & Commits

--- a/plugins/athena-notes/AGENTS.md
+++ b/plugins/athena-notes/AGENTS.md
@@ -142,7 +142,7 @@ Auto-capture these moments without asking — the point of Athena Notes is low-f
 
 Scribe writes immediately on invocation. No previews, no confirmation prompts.
 
-**Scope.** This table covers *vault-note capture* — durable, project-specific knowledge written into Obsidian by `@scribe`. Cross-project user-collaboration preferences (how the user thinks, anchors, decides) route to the harness memory system (e.g., Claude Code auto-memory), not the vault — see `skills/session-review/SKILL.md` for the collaboration-lens flow.
+**Scope.** This table covers *vault-note capture* — durable, project-specific knowledge written into Obsidian by `@scribe`. Cross-project user-collaboration preferences (how the user thinks, anchors, decides) route to the harness memory system, not the vault — see `skills/session-review/SKILL.md` for the collaboration-lens flow.
 
 ---
 

--- a/plugins/athena-notes/AGENTS.md
+++ b/plugins/athena-notes/AGENTS.md
@@ -142,7 +142,7 @@ Auto-capture these moments without asking — the point of Athena Notes is low-f
 
 Scribe writes immediately on invocation. No previews, no confirmation prompts.
 
-**Scope.** This table covers *vault-note capture* — durable, project-specific knowledge written into Obsidian by `@scribe`. Cross-project user-collaboration preferences (how the user thinks, anchors, decides) route to the harness memory system (e.g., Claude Code auto-memory), not the vault — see `skills/session-review/SKILL.md` for the collaboration-lens flow. The plugin owns the router (recognizing the signal), not the memory destination.
+**Scope.** This table covers *vault-note capture* — durable, project-specific knowledge written into Obsidian by `@scribe`. Cross-project user-collaboration preferences (how the user thinks, anchors, decides) route to the harness memory system (e.g., Claude Code auto-memory), not the vault — see `skills/session-review/SKILL.md` for the collaboration-lens flow.
 
 ---
 

--- a/plugins/athena-notes/skills/session-review/SKILL.md
+++ b/plugins/athena-notes/skills/session-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-review
-description: Review conversation sessions for project-specific learnings to document in AGENTS.md and .notes/, and close resolved items on today's daily plan
+description: Review conversation sessions for project-specific learnings (AGENTS.md / .notes/), cross-project user-collaboration preferences (harness memory), and resolved tracked items (today's daily plan)
 ---
 
 # Session Review
@@ -38,12 +38,12 @@ Good sessions produce knowledge that shouldn't live only in your head. This skil
 
 ## Signal Test
 
-Before categorizing or drafting, every candidate must pass **all four** questions. Any "no" drops the candidate.
+Before categorizing or drafting, every candidate must pass the questions that apply to its route — vault-route candidates take all four, memory-route candidates take the subset noted in Step 1.5. Any "no" on a question that applies drops the candidate.
 
-**Exemption:** Daily-plan status updates from Step 1.6 (tracked-item resolutions) skip this filter — they're state changes, not durable insights, and the four questions are tuned for knowledge. A session with zero insight-signal can still close a planned loop.
+**Exemption:** Daily-plan status updates from Step 1.6 (tracked-item resolutions) skip this filter — they're state changes, not durable insights, and the questions are tuned for knowledge. A session with zero insight-signal can still close a planned loop.
 
 1. **Novel.** Is the rule, decision, or pattern already captured in AGENTS.md or an existing `.notes/` note? If so, the existing record *is* the signal.
-2. **Project-specific.** Is this specific to Athena Notes (agents, skills, vaults, identity, hub-spoke, this repo's layout)? General engineering knowledge fails.
+2. **Durable & scoped.** Either project-specific (→ AGENTS.md / `.notes/` — agents, skills, vaults, identity, hub-spoke, this repo's layout) OR a cross-project user-collaboration preference (→ harness memory — how this user thinks, anchors, decides). A transient session vibe isn't durable; a general engineering truism isn't scoped. Neither qualifies.
 3. **Future-actionable.** Will a concrete decision — in a future chat or by your future self — change because this note exists? If removing the note wouldn't change any future outcome, it's a log.
 4. **Readable in six months.** Would the note earn a second look in Obsidian on a Saturday? Scannable (table, bullets, wikilinks, short paragraphs) — or a wall of prose to scroll past? If the latter: compress or drop.
 
@@ -52,6 +52,8 @@ Zero survivors is fine. Better to capture nothing than to grow an archive you ne
 ---
 
 ## Categorization Criteria
+
+**Vault routes** (project-specific findings; written by `@scribe` or direct edits to AGENTS.md / today's daily plan):
 
 | Learning Type | Destination | Target Section | Example |
 |---------------|-------------|----------------|---------|
@@ -63,21 +65,39 @@ Zero survivors is fine. Better to capture nothing than to grow an archive you ne
 | Key insight | .notes/ | SESSION type | "Realized the auth flow requires..." |
 | Tracked-item resolution | today's daily plan | matching line | "`#734 → triaged out-of-scope`" |
 
+**Memory routes** (cross-project collaboration signal; routed to the harness memory system — Claude Code auto-memory or equivalent. If your harness has no memory system, present the finding to the user as a candidate worth recording wherever they keep cross-project preferences):
+
+| Learning Type | Destination | Target | Example |
+|---------------|-------------|--------|---------|
+| User-collaboration preference | Harness memory | feedback / user record | "Leads with standards-alignment, not as a footnote" |
+| Project motivation / stakeholder context | Harness memory | project record | "Auth migration is compliance-driven, not tech-debt cleanup" |
+| External-system pointer | Harness memory | reference record | "Pipeline bugs live in Linear project INGEST" |
+
 ---
 
 ## Workflow
 
 ### Step 1: Scan the conversation
 
-Read back through the session. Look for moments where something was discovered, decided, or clarified. Ignore routine task execution. Flag candidates — no quota. Most sessions produce zero to two.
+Read back through the session with **two lenses**:
+
+- **Technical lens.** Moments where something about the code, architecture, or project state was discovered, decided, or clarified.
+- **Collaboration lens.** Moments where the user redirected your framing, elevated a "minor" suggestion to a main issue, repeatedly anchored to a standard or principle, or endorsed an unusual approach without pushback. Signal about *how the user thinks* — routes to the harness memory system, not AGENTS.md / `.notes/`.
+
+A session can have signal in one lens, both, or neither. Ignore routine task execution. Flag candidates — no quota. Most sessions produce zero to two.
 
 ### Step 1.5: Apply the Signal Test
 
-Run each candidate against the four questions above. Drop any that don't pass all four. This is the filter that does the real work; downstream steps only handle survivors.
+Run each candidate against the four questions above. Drop any that don't pass.
+
+- **Vault-route candidates** (technical lens → AGENTS.md / `.notes/` / daily plan): all four questions must pass.
+- **Memory-route candidates** (collaboration lens → harness memory): only Q2 (durable & scoped) and Q4 (readable in six months) apply. Q1 (novel-in-vault) doesn't fit — memory is a separate index. Q3 (future-actionable) is implicit — collaboration preferences exist precisely to change future decisions.
+
+This is the filter that does the real work; downstream steps only handle survivors.
 
 ### Step 1.6: Scan today's daily plan for resolved items
 
-A session often closes a loop that was tracked on today's daily plan (e.g., `[P3 afternoon] Triage #646 / #734 / #731`). Step 1's conversation scan is artifact-oriented and the Signal Test is insight-tuned, so resolved items slip through both. This step catches them.
+A session often closes a loop that was tracked on today's daily plan (e.g., `[P3 afternoon] Triage #646 / #734 / #731`). Step 1's lenses target knowledge moments (technical discoveries, collaboration patterns); the Signal Test is insight-tuned. Tracked-item resolutions are state changes, so they slip through both. This step catches them.
 
 1. **Resolve today's plan path** (same convention as `workday-planning` Phase 0):
    - Read `~/.claude/athena/identity.md` → `notes_root` (default `~/notes`), `personal_vault` (default `second-brain`), `TZ` (IANA).
@@ -95,10 +115,10 @@ Outputs from this step bypass Steps 1.5, 2, and 3 — they don't need the Signal
 
 ### Step 2: Read existing context
 
-Before drafting anything, check for prior art in **both** places so you don't propose duplicates or orphan the existing knowledge:
+Before drafting anything, check for prior art so you don't propose duplicates or orphan the existing knowledge:
 
 1. **AGENTS.md** — read it (if it exists). Understand the current sections. Skip any learning already captured there.
-2. **`.notes/`** — for each surviving candidate that could plausibly land in `.notes/` (architectural decisions, explorations, key insights — the bottom three rows of the categorization table below), invoke `@archivist` to check whether a note on this topic already exists. If a candidate is unambiguously an AGENTS.md row (convention, anti-pattern, where-to-look), skip the archivist call — `.notes/` isn't its destination.
+2. **`.notes/`** — for each surviving candidate that could plausibly land in `.notes/` (architectural decisions, explorations, key insights — the corresponding rows in the vault-routes table above), invoke `@archivist` to check whether a note on this topic already exists. If a candidate is unambiguously an AGENTS.md row (convention, anti-pattern, where-to-look), skip the archivist call — `.notes/` isn't its destination.
 
    ```
    Task(subagent_type="archivist", prompt="scope: published
@@ -109,12 +129,13 @@ Check for existing notes about {topic}. Return matches with type, path, and a 1-
    Use the `scope:` keyword (not prose like "published notes only") to narrow archivist's search — see the *Scope* section of `plugins/athena-notes/agents/archivist.md`.
 
    If archivist returns a match, treat the candidate as an **update** to that note, not a new one. Draft it using the Update template below.
+3. **Harness memory** — for memory-route candidates (collaboration / project-motivation / external-system-pointer), skip the `@archivist` call. Archivist searches `.notes/`, not the harness memory system. The user — or a hub agent with memory access — is responsible for the dedupe pass at the approval gate.
 
 Run archivist lookups in parallel — emit all Task calls in one assistant message so they run concurrently, not one per turn. This step should add seconds, not minutes.
 
 ### Step 3: Categorize
 
-Map each candidate to a row in the table above. If it doesn't fit any row, it probably isn't worth capturing.
+Map each candidate to a row in the appropriate categorization table above — vault-routes for technical-lens candidates, memory-routes for collaboration-lens candidates. If it doesn't fit any row, it probably isn't worth capturing.
 
 ### Step 4: Draft inline
 
@@ -149,6 +170,10 @@ After user approval, apply the edit directly to AGENTS.md using the Edit tool. M
 ### Step 8: Write approved daily-plan updates
 
 For each approved daily-plan edit from Step 1.6, apply it directly via the Edit tool at the path resolved in Step 1.6. Minimal, in-place edits only — match the existing line by its tracked reference (issue number, task name, time-block tag) and modify it in place. Do not rewrite the plan, do not add new sections, do not reorder items. If the matching line can't be found unambiguously (e.g., the user pivoted the plan between sessions), surface that to the user and skip the write — ask for manual placement rather than guess.
+
+### Step 9: Hand off approved memory recommendations
+
+Memory-route candidates have **no automated write step**. After approval, the skill's job is done — the user (or a hub agent with memory access, e.g. an `athena` invocation that can write to `~/.claude/projects/*/memory/`) makes the actual write. Surface the approved recommendations one more time at the end of the run with the harness-specific destination clearly marked, so the next handoff has everything it needs.
 
 ---
 
@@ -197,6 +222,22 @@ Use this variant when archivist (Step 2) surfaced an existing note on the same t
 *Approve to have @scribe apply this update*
 ```
 
+### Memory recommendation
+
+Use this for collaboration-lens candidates routed to harness memory. The skill doesn't write to memory itself — the template is the handoff artifact for the user or hub agent.
+
+```markdown
+### Proposed Memory Recommendation
+
+**Route:** Harness memory ({user | feedback | project | reference} record)
+**Destination hint:** {e.g., `~/.claude/projects/{slug}/memory/{name}.md` for Claude Code auto-memory; otherwise wherever your harness keeps cross-project preferences}
+**Trigger moment:** {one-line — the conversation moment this surfaced from}
+
+{One-paragraph draft of the preference / motivation / pointer, written so it's recognizable in six months without re-reading the session.}
+
+*Approve to surface this for memory write at the end of the run. The skill itself does not write to memory.*
+```
+
 ### Daily-plan update
 
 Use this for Step 1.6 outputs. Show the existing line and the proposed replacement so the user can eyeball the edit before approving.
@@ -220,7 +261,7 @@ Use this for Step 1.6 outputs. Show the existing line and the proposed replaceme
 
 ## Edge Cases
 
-**No survivors (common):** Most sessions execute rather than discover. If Step 1.6 also found no daily-plan items to close, report `No signal — routine execution` and stop. This isn't failure; it's the expected outcome. If Step 1.6 did surface daily-plan edits, present those alone at the approval gate — a session with zero insight-signal is still allowed to close a planned loop.
+**No survivors (common):** Most sessions execute rather than discover. "No survivors" means **both lenses** dropped to zero AND Step 1.6 found no daily-plan items to close. When all three are empty, report `No signal — routine execution` and stop. This isn't failure; it's the expected outcome. If only one channel has output (e.g., the collaboration lens surfaced a single user-preference candidate, or Step 1.6 surfaced a daily-plan edit), present that alone at the approval gate — a session with signal in just one channel is still allowed to close.
 
 **No daily plan for today:** Step 1.6 handles this — silently skip, no prompt.
 
@@ -242,3 +283,5 @@ Use this for Step 1.6 outputs. Show the existing line and the proposed replaceme
 - Do NOT handle worktree path resolution — that's @scribe's job via the agent-workspace skill. (Daily-plan paths are personal-vault paths, not worktree paths; Step 1.6 resolves them directly from identity config.)
 - Do NOT write prose-heavy narratives. Notes must be scannable in Obsidian at a glance — tables, bullets, wikilinks to related notes, short paragraphs. A 300-word reflective essay is the failure mode, not the goal.
 - Do NOT hit a quota. If only one candidate survives the Signal Test, propose one. If none survive, propose none. Never pad.
+- Do NOT report `No signal — routine execution` without confirming **both** lenses (technical + collaboration) ran. Zero-from-technical with the collaboration lens unchecked is a premature close.
+- Do NOT write to harness memory directly. Memory-route candidates are presented at the approval gate as recommendations; the user (or a hub agent with memory access) makes the actual write. The skill is a router, not the destination owner.

--- a/plugins/athena-notes/skills/session-review/SKILL.md
+++ b/plugins/athena-notes/skills/session-review/SKILL.md
@@ -144,7 +144,7 @@ Run archivist lookups in parallel — emit all Task calls in one assistant messa
 
 ### Step 3: Categorize
 
-Map each candidate to the row that fits its content. Routing is by row, not by lens (see Step 1.5). If it doesn't fit any row, it probably isn't worth capturing.
+Map each candidate to the row that fits its content (see Step 1.5 for the routing rule). If it doesn't fit any row, it probably isn't worth capturing.
 
 ### Step 4: Draft inline
 
@@ -292,5 +292,5 @@ Use this for Step 1.6 outputs. Show the existing line and the proposed replaceme
 - Do NOT handle worktree path resolution — that's @scribe's job via the agent-workspace skill. (Daily-plan paths are personal-vault paths, not worktree paths; Step 1.6 resolves them directly from identity config.)
 - Do NOT write prose-heavy narratives. Notes must be scannable in Obsidian at a glance — tables, bullets, wikilinks to related notes, short paragraphs. A 300-word reflective essay is the failure mode, not the goal.
 - Do NOT hit a quota. If only one candidate survives the Signal Test, propose one. If none survive, propose none. Never pad.
-- Do NOT report `No signal — routine execution` without confirming both lenses ran (see Edge Cases — No survivors).
+- Do NOT report `No signal — routine execution` without confirming all three channels came up empty (see Edge Cases — No survivors).
 - Do NOT write to harness memory directly. Memory-route candidates are presented at the approval gate as recommendations; the user (or a hub agent with memory access) makes the actual write. The skill is a router, not the destination owner.

--- a/plugins/athena-notes/skills/session-review/SKILL.md
+++ b/plugins/athena-notes/skills/session-review/SKILL.md
@@ -78,7 +78,7 @@ Zero survivors is fine. Better to capture nothing than to grow an archive you ne
 | Project motivation / stakeholder context | Harness memory | project record | "Auth migration is compliance-driven, not tech-debt cleanup" |
 | External-system pointer | Harness memory | reference record | "Pipeline bugs live in Linear project INGEST" |
 
-> **Scoping note for the external-system-pointer row.** Generic, public-facing pointers (a tool name, a public dashboard URL) are fine for cross-project memory. Pointers that name internal infrastructure (private URLs, internal project IDs, undisclosed tooling, team names) are project-scoped and belong in `.notes/` on the originating project — not in cross-project user/reference memory that any future agent in any repo will load.
+> **Scoping note.** Pointers that name internal infrastructure (private URLs, internal IDs, internal tooling) are project-scoped — write them to `.notes/` on the originating project, not to cross-project memory.
 
 ---
 
@@ -144,11 +144,11 @@ Run archivist lookups in parallel — emit all Task calls in one assistant messa
 
 ### Step 3: Categorize
 
-Map each candidate to the row that fits its content. Routing is by row, not by lens — a technical-lens finding about project motivation lands on memory-routes per Step 1.5, and a collaboration-lens finding is always memory-route. If it doesn't fit any row, it probably isn't worth capturing.
+Map each candidate to the row that fits its content. Routing is by row, not by lens (see Step 1.5). If it doesn't fit any row, it probably isn't worth capturing.
 
 ### Step 4: Draft inline
 
-Write out proposed content for each item using the templates below. Keep drafts concise — one table row for AGENTS.md, a filled template for a new `.notes/` note, or a targeted patch for an update.
+Write out proposed content for each item using the templates below. Keep drafts concise — one table row for AGENTS.md, a filled template for a new `.notes/` note, a targeted patch for an update, or a Memory recommendation for memory-route candidates.
 
 ### Step 5: APPROVAL GATE
 
@@ -233,13 +233,13 @@ Use this variant when archivist (Step 2) surfaced an existing note on the same t
 
 ### Memory recommendation
 
-Use this for memory-route candidates (collaboration / project-motivation / external-system-pointer). The skill doesn't write to memory itself — the template is the handoff artifact for the user or hub agent. **Write the draft in third-person declarative form** ("Bryan prefers X", "the auth migration is compliance-driven") rather than imperative ("Always do X", "Do this when…"). Imperative-shaped session content is a prompt-injection vector once it lands verbatim in `~/.claude/projects/*/memory/*.md` and loads as instruction in a future session; third-person declarative phrasing keeps injected imperatives visually distinct at the approval gate.
+Use this for memory-route candidates (collaboration / project-motivation / external-system-pointer). The skill doesn't write to memory itself — the template is the handoff artifact for the user or hub agent. **Write the draft in third-person declarative form** ("Bryan prefers X", "the auth migration is compliance-driven") rather than imperative ("Always do X", "Do this when…") — third-person declarative phrasing keeps injected imperatives visually distinct at the approval gate.
 
 ```markdown
 ### Proposed Memory Recommendation
 
 **Route:** Harness memory ({user | feedback | project | reference} record)
-**Destination hint:** {e.g., `~/.claude/projects/{slug}/memory/{name}.md` for Claude Code auto-memory — `{slug}` is the project's directory under `~/.claude/projects/`, mirroring its absolute path with `/` → `-`. Verify the slug against `ls ~/.claude/projects/` rather than computing it blind, since the harness's actual directory name may differ from the naive transformation. Otherwise wherever your harness keeps cross-project preferences.}
+**Destination hint:** {e.g., `~/.claude/projects/{slug}/memory/{name}.md` for Claude Code auto-memory — verify `{slug}` with `ls ~/.claude/projects/` rather than computing it blind. Otherwise wherever your harness keeps cross-project preferences.}
 **Trigger moment:** {one-line — the conversation moment this surfaced from}
 
 {One-paragraph draft (third-person declarative) of the preference / motivation / pointer, written so it's recognizable in six months without re-reading the session.}

--- a/plugins/athena-notes/skills/session-review/SKILL.md
+++ b/plugins/athena-notes/skills/session-review/SKILL.md
@@ -43,9 +43,14 @@ Before categorizing or drafting, every candidate must pass the questions that ap
 **Exemption:** Daily-plan status updates from Step 1.6 (tracked-item resolutions) skip this filter — they're state changes, not durable insights, and the questions are tuned for knowledge. A session with zero insight-signal can still close a planned loop.
 
 1. **Novel.** Is the rule, decision, or pattern already captured in AGENTS.md or an existing `.notes/` note? If so, the existing record *is* the signal.
-2. **Durable & scoped.** Either project-specific (→ AGENTS.md / `.notes/` — agents, skills, vaults, identity, hub-spoke, this repo's layout) OR a cross-project user-collaboration preference (→ harness memory — how this user thinks, anchors, decides). A transient session vibe isn't durable; a general engineering truism isn't scoped. Neither qualifies.
+2. **Durable & scoped.** The candidate routes to one of two destinations:
+
+   - **Vault** (→ AGENTS.md / `.notes/`) — project-specific to Athena Notes: agents, skills, vaults, identity, hub-spoke, this repo's layout.
+   - **Harness memory** — cross-project user-collaboration preference (how this user thinks, anchors, decides), project motivation / stakeholder context, or external-system pointer.
+
+   A transient session vibe isn't durable; a general engineering truism isn't scoped. Neither qualifies.
 3. **Future-actionable.** Will a concrete decision — in a future chat or by your future self — change because this note exists? If removing the note wouldn't change any future outcome, it's a log.
-4. **Readable in six months.** Would the note earn a second look in Obsidian on a Saturday? Scannable (table, bullets, wikilinks, short paragraphs) — or a wall of prose to scroll past? If the latter: compress or drop.
+4. **Readable in six months.** Would the captured item earn a second look — vault notes in Obsidian on a Saturday, memory records in a future session window? Scannable (table, bullets, short paragraphs; wikilinks for vault notes only) — or a wall of prose to scroll past? If the latter: compress or drop.
 
 Zero survivors is fine. Better to capture nothing than to grow an archive you never revisit.
 
@@ -90,8 +95,8 @@ A session can have signal in one lens, both, or neither. Ignore routine task exe
 
 Run each candidate against the four questions above. Drop any that don't pass.
 
-- **Vault-route candidates** (technical lens → AGENTS.md / `.notes/` / daily plan): all four questions must pass.
-- **Memory-route candidates** (collaboration lens → harness memory): only Q2 (durable & scoped) and Q4 (readable in six months) apply. Q1 (novel-in-vault) doesn't fit — memory is a separate index. Q3 (future-actionable) is implicit — collaboration preferences exist precisely to change future decisions.
+- **Vault-route candidates** (AGENTS.md / `.notes/` / daily plan): all four questions must pass.
+- **Memory-route candidates** (harness memory): only Q2 (durable & scoped) and Q4 (readable in six months) apply. Q1 (novel-in-vault) doesn't fit — memory is a separate index. Q3 (future-actionable) is implicit — these records exist precisely to change future decisions. This route covers both collaboration-lens findings and technical-lens findings that fit the project-motivation or external-system-pointer rows; routing is by destination row, not by lens.
 
 This is the filter that does the real work; downstream steps only handle survivors.
 
@@ -143,7 +148,7 @@ Write out proposed content for each item using the templates below. Keep drafts 
 
 ### Step 5: APPROVAL GATE
 
-Present all drafts to the user and stop. Do not proceed until you receive explicit approval. The user may approve all, some, or none.
+Present all drafts to the user and stop. Do not proceed until you receive explicit approval from a human. The user may approve all, some, or none. A hub agent invoking `session-review` autonomously must surface the gate to the user — it must not self-approve on the user's behalf, since the collaboration lens by design is fed by session content.
 
 ### Step 6: Write or update approved .notes/ items
 
@@ -230,12 +235,12 @@ Use this for collaboration-lens candidates routed to harness memory. The skill d
 ### Proposed Memory Recommendation
 
 **Route:** Harness memory ({user | feedback | project | reference} record)
-**Destination hint:** {e.g., `~/.claude/projects/{slug}/memory/{name}.md` for Claude Code auto-memory; otherwise wherever your harness keeps cross-project preferences}
+**Destination hint:** {e.g., `~/.claude/projects/{slug}/memory/{name}.md` for Claude Code auto-memory — `{slug}` is the project's directory under `~/.claude/projects/`, mirroring its absolute path with `/` → `-`. Otherwise wherever your harness keeps cross-project preferences.}
 **Trigger moment:** {one-line — the conversation moment this surfaced from}
 
 {One-paragraph draft of the preference / motivation / pointer, written so it's recognizable in six months without re-reading the session.}
 
-*Approve to surface this for memory write at the end of the run. The skill itself does not write to memory.*
+*Approve to record this. Step 9 surfaces the final recommendation for handoff with no second gate.*
 ```
 
 ### Daily-plan update

--- a/plugins/athena-notes/skills/session-review/SKILL.md
+++ b/plugins/athena-notes/skills/session-review/SKILL.md
@@ -78,6 +78,8 @@ Zero survivors is fine. Better to capture nothing than to grow an archive you ne
 | Project motivation / stakeholder context | Harness memory | project record | "Auth migration is compliance-driven, not tech-debt cleanup" |
 | External-system pointer | Harness memory | reference record | "Pipeline bugs live in Linear project INGEST" |
 
+> **Scoping note for the external-system-pointer row.** Generic, public-facing pointers (a tool name, a public dashboard URL) are fine for cross-project memory. Pointers that name internal infrastructure (private URLs, internal project IDs, undisclosed tooling, team names) are project-scoped and belong in `.notes/` on the originating project — not in cross-project user/reference memory that any future agent in any repo will load.
+
 ---
 
 ## Workflow
@@ -96,7 +98,9 @@ A session can have signal in one lens, both, or neither. Ignore routine task exe
 Run each candidate against the four questions above. Drop any that don't pass.
 
 - **Vault-route candidates** (AGENTS.md / `.notes/` / daily plan): all four questions must pass.
-- **Memory-route candidates** (harness memory): only Q2 (durable & scoped) and Q4 (readable in six months) apply. Q1 (novel-in-vault) doesn't fit — memory is a separate index. Q3 (future-actionable) is implicit — these records exist precisely to change future decisions. This route covers both collaboration-lens findings and technical-lens findings that fit the project-motivation or external-system-pointer rows; routing is by destination row, not by lens.
+- **Memory-route candidates** (harness memory): Q2 (durable & scoped), Q3 (future-actionable), and Q4 (readable in six months) all apply. Q1 (novel-in-vault) doesn't — memory is a separate index from the vault. A preference that wouldn't change any future agent decision still fails Q3.
+
+Routing is by destination row, not by which lens flagged the candidate — a technical-lens finding can land on memory-routes if it fits a project-motivation or external-system-pointer row, and a collaboration-lens finding is always memory-route. See Step 3.
 
 This is the filter that does the real work; downstream steps only handle survivors.
 
@@ -140,7 +144,7 @@ Run archivist lookups in parallel — emit all Task calls in one assistant messa
 
 ### Step 3: Categorize
 
-Map each candidate to a row in the appropriate categorization table above — vault-routes for technical-lens candidates, memory-routes for collaboration-lens candidates. If it doesn't fit any row, it probably isn't worth capturing.
+Map each candidate to the row that fits its content. Routing is by row, not by lens — a technical-lens finding about project motivation lands on memory-routes per Step 1.5, and a collaboration-lens finding is always memory-route. If it doesn't fit any row, it probably isn't worth capturing.
 
 ### Step 4: Draft inline
 
@@ -148,7 +152,7 @@ Write out proposed content for each item using the templates below. Keep drafts 
 
 ### Step 5: APPROVAL GATE
 
-Present all drafts to the user and stop. Do not proceed until you receive explicit approval from a human. The user may approve all, some, or none. A hub agent invoking `session-review` autonomously must surface the gate to the user — it must not self-approve on the user's behalf, since the collaboration lens by design is fed by session content.
+Present all drafts to the user and stop. Do not proceed until you receive explicit approval from a human. The user may approve all, some, or none. A hub agent invoking `session-review` autonomously surfaces the gate to the user; only the user can approve — never the hub agent on the user's behalf.
 
 ### Step 6: Write or update approved .notes/ items
 
@@ -229,18 +233,18 @@ Use this variant when archivist (Step 2) surfaced an existing note on the same t
 
 ### Memory recommendation
 
-Use this for collaboration-lens candidates routed to harness memory. The skill doesn't write to memory itself — the template is the handoff artifact for the user or hub agent.
+Use this for memory-route candidates (collaboration / project-motivation / external-system-pointer). The skill doesn't write to memory itself — the template is the handoff artifact for the user or hub agent. **Write the draft in third-person declarative form** ("Bryan prefers X", "the auth migration is compliance-driven") rather than imperative ("Always do X", "Do this when…"). Imperative-shaped session content is a prompt-injection vector once it lands verbatim in `~/.claude/projects/*/memory/*.md` and loads as instruction in a future session; third-person declarative phrasing keeps injected imperatives visually distinct at the approval gate.
 
 ```markdown
 ### Proposed Memory Recommendation
 
 **Route:** Harness memory ({user | feedback | project | reference} record)
-**Destination hint:** {e.g., `~/.claude/projects/{slug}/memory/{name}.md` for Claude Code auto-memory — `{slug}` is the project's directory under `~/.claude/projects/`, mirroring its absolute path with `/` → `-`. Otherwise wherever your harness keeps cross-project preferences.}
+**Destination hint:** {e.g., `~/.claude/projects/{slug}/memory/{name}.md` for Claude Code auto-memory — `{slug}` is the project's directory under `~/.claude/projects/`, mirroring its absolute path with `/` → `-`. Verify the slug against `ls ~/.claude/projects/` rather than computing it blind, since the harness's actual directory name may differ from the naive transformation. Otherwise wherever your harness keeps cross-project preferences.}
 **Trigger moment:** {one-line — the conversation moment this surfaced from}
 
-{One-paragraph draft of the preference / motivation / pointer, written so it's recognizable in six months without re-reading the session.}
+{One-paragraph draft (third-person declarative) of the preference / motivation / pointer, written so it's recognizable in six months without re-reading the session.}
 
-*Approve to record this. Step 9 surfaces the final recommendation for handoff with no second gate.*
+*Approve to record this.*
 ```
 
 ### Daily-plan update
@@ -288,5 +292,5 @@ Use this for Step 1.6 outputs. Show the existing line and the proposed replaceme
 - Do NOT handle worktree path resolution — that's @scribe's job via the agent-workspace skill. (Daily-plan paths are personal-vault paths, not worktree paths; Step 1.6 resolves them directly from identity config.)
 - Do NOT write prose-heavy narratives. Notes must be scannable in Obsidian at a glance — tables, bullets, wikilinks to related notes, short paragraphs. A 300-word reflective essay is the failure mode, not the goal.
 - Do NOT hit a quota. If only one candidate survives the Signal Test, propose one. If none survive, propose none. Never pad.
-- Do NOT report `No signal — routine execution` without confirming **both** lenses (technical + collaboration) ran. Zero-from-technical with the collaboration lens unchecked is a premature close.
+- Do NOT report `No signal — routine execution` without confirming both lenses ran (see Edge Cases — No survivors).
 - Do NOT write to harness memory directly. Memory-route candidates are presented at the approval gate as recommendations; the user (or a hub agent with memory access) makes the actual write. The skill is a router, not the destination owner.

--- a/plugins/athena-notes/skills/session-review/SKILL.md
+++ b/plugins/athena-notes/skills/session-review/SKILL.md
@@ -100,7 +100,7 @@ Run each candidate against the four questions above. Drop any that don't pass.
 - **Vault-route candidates** (AGENTS.md / `.notes/` / daily plan): all four questions must pass.
 - **Memory-route candidates** (harness memory): Q2 (durable & scoped), Q3 (future-actionable), and Q4 (readable in six months) all apply. Q1 (novel-in-vault) doesn't — memory is a separate index from the vault. A preference that wouldn't change any future agent decision still fails Q3.
 
-Routing is by destination row, not by which lens flagged the candidate — a technical-lens finding can land on memory-routes if it fits a project-motivation or external-system-pointer row, and a collaboration-lens finding is always memory-route. See Step 3.
+Routing is by destination row, not by which lens flagged the candidate — a technical-lens finding can land on memory-routes if it fits a project-motivation or external-system-pointer row.
 
 This is the filter that does the real work; downstream steps only handle survivors.
 
@@ -233,7 +233,7 @@ Use this variant when archivist (Step 2) surfaced an existing note on the same t
 
 ### Memory recommendation
 
-Use this for memory-route candidates (collaboration / project-motivation / external-system-pointer). The skill doesn't write to memory itself — the template is the handoff artifact for the user or hub agent. **Write the draft in third-person declarative form** ("Bryan prefers X", "the auth migration is compliance-driven") rather than imperative ("Always do X", "Do this when…") — third-person declarative phrasing keeps injected imperatives visually distinct at the approval gate.
+Use this for memory-route candidates (collaboration / project-motivation / external-system-pointer). The skill doesn't write to memory itself — the template is the handoff artifact for the user or hub agent. **Write the draft in third-person declarative form** ("[User] prefers X", "the auth migration is compliance-driven") rather than imperative ("Always do X", "Do this when…") — third-person declarative phrasing keeps injected imperatives visually distinct at the approval gate.
 
 ```markdown
 ### Proposed Memory Recommendation
@@ -270,7 +270,7 @@ Use this for Step 1.6 outputs. Show the existing line and the proposed replaceme
 
 ## Edge Cases
 
-**No survivors (common):** Most sessions execute rather than discover. "No survivors" means **both lenses** dropped to zero AND Step 1.6 found no daily-plan items to close. When all three are empty, report `No signal — routine execution` and stop. This isn't failure; it's the expected outcome. If only one channel has output (e.g., the collaboration lens surfaced a single user-preference candidate, or Step 1.6 surfaced a daily-plan edit), present that alone at the approval gate — a session with signal in just one channel is still allowed to close.
+**No survivors (common):** Most sessions execute rather than discover. "No survivors" means all three channels — technical lens, collaboration lens, and the Step 1.6 daily-plan scan — came up empty. When that's the case, report `No signal — routine execution` and stop. This isn't failure; it's the expected outcome. If only one channel has output (e.g., the collaboration lens surfaced a single user-preference candidate, or Step 1.6 surfaced a daily-plan edit), present that alone at the approval gate — a session with signal in just one channel is still allowed to close.
 
 **No daily plan for today:** Step 1.6 handles this — silently skip, no prompt.
 


### PR DESCRIPTION
## Summary

Adds a **collaboration lens** to `session-review` so the skill can catch cross-project user-collaboration signal (how the user thinks, what they anchor on) — not just technical artifacts. Routes those findings to the harness memory system instead of vault notes; the plugin owns the router, not the destination.

- Step 1 scans with two lenses (technical + collaboration).
- Signal Test Q2 softened — durability/scope check now allows either project-specific (vault) or cross-project user-preference (memory).
- Categorization Criteria split into vault-routes (existing) and memory-routes (new: user-collaboration preference / project motivation / external-system pointer).
- Step 5 explicitly requires *human* approval — a hub agent invoking session-review autonomously must surface the gate, not self-approve, since the collaboration lens is fed by session content.
- New Step 9 hands approved memory recommendations off to the user (or a hub agent with memory access). The skill never writes to memory itself.
- Hub Capture Triggers in `AGENTS.md` carry an explicit scope note: the table covers vault-note capture; cross-project preferences route to harness memory per `session-review`'s lens.

Closes #13.

### Self-review findings

Three-lens self-review surfaced 1 Major + 5 Minor + 3 Nit findings. 7 accepted and fixed in the second commit (`809bd42`); 2 pushed back with rationale (Q1/Q3 inline justification stays — helps an LLM interpreter judge edge cases; Step 9 dir-level path stays — different scope from the template's file-level destination hint).

The Major was a real routing bug introduced in the first commit: memory-routes table had `project motivation` and `external-system pointer` rows that the lens-keyed routing in Step 1.5 never reached, since those can surface from the *technical* lens (e.g., discovering an auth migration is compliance-driven). Fixed by routing-by-destination-row, not by lens, and rephrasing Q2 as a vault-vs-memory sub-list (which collaterally addresses the simplicity Q2-density nit). Full triage in `~/.claude/issue-work/SnowboardTechie-athena-notes-13/summary.md`.

## Test plan

- [x] `python3 scripts/lint-frontmatter.py plugins/athena-notes/skills/session-review/SKILL.md plugins/athena-notes/AGENTS.md` — passes (14 agents, 18 skills validated).
- [x] End-to-end readback of the edited SKILL.md — Step 1 → 1.5 → 1.6 → 2 → 3 → 4 → 5 → 6/7/8/9 hangs together; vault path and memory path are both internally consistent; routing-by-destination wording is unambiguous.
- [x] AGENTS.md scope note read in context — fits existing tone, no new section, doesn't duplicate Capture Triggers row content.
- [x] CI on push: `frontmatter-lint`, `docs-lint`, `version-check` (CHANGELOG.md is in the diff alongside the versionable paths so version-check is satisfied; non-release PR — no `plugin.json` bump).

Functional verification of the new collaboration-lens flow happens the next time `/session-review` runs against a session with collab signal — markdown skill bodies don't have unit tests in this repo.

## Changelog

- [x] **Non-release PR** — added a bullet under `## [Unreleased]` in `CHANGELOG.md`.
- [ ] **Release PR (`vX.Y.Z`)** — N/A
- [ ] **Exempt** — N/A (touched a versionable path: `plugins/athena-notes/skills/session-review/SKILL.md`)
