### PR TITLE
issue-create: search for parent issue via GraphQL before posting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 ## [Unreleased]
 
 ### Changed
-- `issue-create` skill — always searches for a candidate parent issue before posting (new Stage 2.3: GraphQL `issue.parent` on seed `#N` references and label-cluster siblings, single-select prompt with up to 3 suggestions plus `Specify` and `No parent`) and links the new issue via `addSubIssue` after creation when the user confirms a parent (new Stage 4.5, mutation + verify, mirrors 4.3+4.4). Forgejo path skips silently; both new GraphQL calls send `GraphQL-Features: sub_issues` for the public-preview API. Resolves [#47](https://github.com/SnowboardTechie/athena-notes/issues/47).
+- `issue-create` skill — searches for a candidate parent issue before posting (Stage 2.3) and links via `addSubIssue` after creation when the user confirms (Stage 4.5); Forgejo path skips silently. Resolves [#47](https://github.com/SnowboardTechie/athena-notes/issues/47).
 - `workday-planning` skill — Phase 8 now opens with a persistence receipt: `✅ Wrote: …` on a fresh write, `⏭️ Kept existing: …` when the user declines to overwrite. Resolves [#30](https://github.com/SnowboardTechie/athena-notes/issues/30).
 
 ## [0.4.3] — 2026-04-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 ## [Unreleased]
 
 ### Changed
+- `issue-create` skill — always searches for a candidate parent issue before posting (new Stage 2.3: GraphQL `issue.parent` on seed `#N` references and label-cluster siblings, single-select prompt with up to 3 suggestions plus `Specify` and `No parent`) and links the new issue via `addSubIssue` after creation when the user confirms a parent (new Stage 4.5, mutation + verify, mirrors 4.3+4.4). Forgejo path skips silently; both new GraphQL calls send `GraphQL-Features: sub_issues` for the public-preview API. Resolves [#47](https://github.com/SnowboardTechie/athena-notes/issues/47).
 - `workday-planning` skill — Phase 8 now opens with a persistence receipt: `✅ Wrote: …` on a fresh write, `⏭️ Kept existing: …` when the user declines to overwrite. Resolves [#30](https://github.com/SnowboardTechie/athena-notes/issues/30).
 
 ## [0.4.3] — 2026-04-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 ## [Unreleased]
 
 ### Changed
-- `issue-create` skill — searches for a candidate parent issue before posting (Stage 2.3) and links via `addSubIssue` after creation when the user confirms (Stage 4.5); Forgejo path skips silently. Resolves [#47](https://github.com/SnowboardTechie/athena-notes/issues/47).
+- `issue-create` skill — searches for a candidate parent issue before posting and links the new issue under it when the user confirms; Forgejo path skips silently. Resolves [#47](https://github.com/SnowboardTechie/athena-notes/issues/47).
 - `workday-planning` skill — Phase 8 now opens with a persistence receipt: `✅ Wrote: …` on a fresh write, `⏭️ Kept existing: …` when the user declines to overwrite. Resolves [#30](https://github.com/SnowboardTechie/athena-notes/issues/30).
 
 ## [0.4.3] — 2026-04-23

--- a/plugins/athena-notes/skills/issue-create/SKILL.md
+++ b/plugins/athena-notes/skills/issue-create/SKILL.md
@@ -237,6 +237,107 @@ Branch on a successful response:
 - **Exactly one open linked project** → attach it automatically. One linked project is unambiguous, so no prompt. Capture the title for Stage 4.2's `--project` flag.
 - **Two or more open linked projects** → `AskUserQuestion` single-select with each title plus `(none)`. Capture the selection (empty when `(none)`).
 
+### 2.3 Parent linkage (GitHub only)
+
+Forgejo has no native sub-issue concept — skip this entire subsection silently on the Forgejo path. The flow continues to Stage 3 with `parent` empty in the draft frontmatter.
+
+**Always search.** Even when the candidate set is empty, prompt the user — never silently skip. Some issues legitimately have no parent, but that's the user's call.
+
+#### 2.3.1 Build the candidate set
+
+Combine two sources:
+
+1. **Seed `#N` references.** Scan the user's initial framing and Q&A answers for bare `#N` patterns. Drop any cross-repo `{owner}/{repo}#N` references — this skill only links within the target repo. Capture the bare numbers.
+
+2. **Label-cluster siblings.** Open issues in the target repo that share **all** selected labels (full intersection). Build the search query explicitly so label semantics are unambiguous (`gh issue list --label` repetition is AND in current `gh` versions, but `--search` makes the intent local to this file):
+
+   ```bash
+   search_terms=""
+   for l in "${selected_labels[@]}"; do
+     if [[ "$l" == *" "* ]]; then
+       search_terms+=" label:\"$l\""
+     else
+       search_terms+=" label:$l"
+     fi
+   done
+   search_terms="${search_terms# }"  # trim leading space
+
+   gh issue list \
+     --repo "$owner/$repo" \
+     --state open \
+     --search "$search_terms" \
+     --limit 20 \
+     --json number \
+     --jq '.[].number'
+   ```
+
+   If no labels were selected in 2.2, skip the label-cluster source entirely — full-intersection on zero labels matches every open issue, which is noise.
+
+Merge the two sources, dedupe, and exclude any number the user already named as the parent in their seed (e.g. "this is a follow-up to #656" — `#656` is the candidate parent, not a sibling). Cap the merged set at 20.
+
+If the merged set is empty → skip 2.3.2 and 2.3.3, jump to 2.3.4 (still prompt, with `(no candidates detected)`).
+
+#### 2.3.2 Query each candidate's parent
+
+One batched GraphQL request, with one alias per candidate. The `sub_issues` preview header is required for both the read here and the mutation in Stage 4.5; without it the `parent` field returns `Field 'parent' doesn't exist on type 'Issue'`.
+
+```bash
+# Build the alias list dynamically. Example shape:
+#   query($owner: String!, $repo: String!) {
+#     repository(owner: $owner, name: $repo) {
+#       i123: issue(number: 123) { parent { number title url state } }
+#       i456: issue(number: 456) { parent { number title url state } }
+#       ...
+#     }
+#   }
+
+aliases=""
+for n in "${candidates[@]}"; do
+  aliases+="i${n}: issue(number: ${n}) { parent { number title url state } }
+"
+done
+
+gh api graphql \
+  -H "GraphQL-Features: sub_issues" \
+  -f query="
+    query(\$owner: String!, \$repo: String!) {
+      repository(owner: \$owner, name: \$repo) {
+        $aliases
+      }
+    }
+  " \
+  -f owner="$owner" -f repo="$repo" \
+  --jq '.data.repository | to_entries | map(select(.value != null and .value.parent != null)) | map({sibling: (.key | sub("^i"; "") | tonumber), parent: .value.parent})'
+```
+
+The `--jq` filter drops candidates with `null` parents (and any `null` issues — a bad number in the input set returns `null` rather than an error) and reshapes the rest into `[{sibling, parent: {number, title, url, state}}, …]`.
+
+If the GraphQL call itself fails (non-zero exit, error in response — most commonly the `sub_issues` preview not enabled on the account, or rate limit), surface the error and ask: *"Parent search failed ({error}). Continue posting without parent linkage? [yes / stop]"*. Treat silence or any non-`yes` reply as stop. Do not silently fall through — that's the same failure mode Stage 2.2 Project guards against.
+
+#### 2.3.3 Find convergence
+
+Tally parent numbers across the surviving candidates:
+
+- **Single agreed parent** (all non-null candidates point to the same parent) → primary suggestion.
+- **Mixed parents** → sort by count descending; take up to 3 distinct parents as suggestions, primary first.
+- **All candidates had `null` parent** → no suggestions; fall through to 2.3.4 with `(no parent detected among siblings)`.
+
+For each surfaced parent, append ` (closed)` to the option label when the parent's `state == "CLOSED"` so the user sees the state without an extra click.
+
+#### 2.3.4 Ask the user
+
+Use `AskUserQuestion` single-select. Always include all of:
+
+- One option per surfaced candidate parent (up to 3): `Link under #N — {title}` or `Link under #N — {title} (closed)`.
+- `Specify a different parent` — on selection, ask a follow-up turn: *"Parent issue number? (e.g. `42`, or `skip`)"*. Validate the answer parses as a positive integer; on invalid input or `skip`, treat as `No parent`.
+- `No parent` — default. The natural choice when no candidates surfaced or the user has none in mind.
+
+Capture the result as a single integer (parent issue number) or empty.
+
+#### 2.3.5 Persist on the draft
+
+In Stage 3.2's frontmatter, write `parent: {N}` (or empty when not chosen). The actual link happens in Stage 4.5 after the issue is created — at draft time we only need to remember the choice.
+
 ---
 
 ## Stage 3 — Draft & review
@@ -274,6 +375,7 @@ title: {chosen title}
 labels: [{selected labels}]
 milestone: {selected milestone or empty}
 project: {selected project or empty}
+parent: {parent issue number from Stage 2.3, or empty}
 type: {template's type: field, or empty}
 created: {iso8601}
 ---
@@ -510,9 +612,70 @@ verified_type=$(gh api graphql -f query='
 - **Empty** → wait 2 seconds, retry the mutation from 4.3.2 once, then re-verify.
 - **Still empty after retry** → report: "Issue #{N} created but type not set. Retry manually: `gh api graphql -f query='mutation { updateIssueIssueType(input: {issueId: \"$issue_node_id\", issueTypeId: \"$type_id\"}) { issue { issueType { name } } } }'`." Continue to 4.5 anyway — the issue exists.
 
-### 4.5 Archive the draft
+### 4.5 Link parent issue (GitHub only, when `parent` set in 2.3)
 
-On successful post (type set or type not needed — i.e., Forgejo, no-template, or verified non-null after 4.4):
+Skip this stage entirely when:
+
+- `forge == forgejo` (no native sub-issue concept), or
+- The draft's `parent:` field is empty (user picked `No parent` in 2.3.4).
+
+Otherwise, link the new issue under the chosen parent. Mirrors the 4.3+4.4 pattern: mutation, then verify, then one retry on failure.
+
+#### 4.5.1 Resolve node IDs
+
+The new issue's node ID was already resolved in 4.3.2 as `$issue_node_id`. Reuse it (resolve it here if 4.3 was skipped, e.g. no-template path):
+
+```bash
+[[ -z "$issue_node_id" ]] && issue_node_id=$(gh api "repos/$owner/$repo/issues/$new_issue_number" --jq '.node_id')
+parent_node_id=$(gh api "repos/$owner/$repo/issues/$parent_number" --jq '.node_id' 2>/dev/null)
+```
+
+If the parent number doesn't exist (404, empty `parent_node_id`), report `"Parent #$parent_number not found in $owner/$repo — skipping linkage."` and continue to 4.6 without linking. The issue exists; the orphaned parent number is a user mistake, not a posting failure.
+
+#### 4.5.2 Call addSubIssue
+
+The `sub_issues` preview header is required. Without it the mutation returns `Field 'addSubIssue' doesn't exist on type 'Mutation'`.
+
+```bash
+gh api graphql \
+  -H "GraphQL-Features: sub_issues" \
+  -f query='
+    mutation($parentId: ID!, $childId: ID!) {
+      addSubIssue(input: {issueId: $parentId, subIssueId: $childId}) {
+        subIssue { number }
+      }
+    }
+  ' -f parentId="$parent_node_id" -f childId="$issue_node_id"
+```
+
+#### 4.5.3 Verify
+
+Re-query the new issue's `parent.number` and compare against the chosen parent:
+
+```bash
+verified_parent=$(gh api graphql \
+  -H "GraphQL-Features: sub_issues" \
+  -f query='
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $number) {
+          parent { number }
+        }
+      }
+    }
+  ' -f owner="$owner" -f repo="$repo" -F number="$new_issue_number" \
+    --jq '.data.repository.issue.parent.number // ""')
+```
+
+`// ""` turns a JSON `null` into an empty string (same pattern as 4.4) so `[[ -z ... ]]` is reliable.
+
+- **Matches `$parent_number`** → success. Continue to 4.6.
+- **Empty or mismatched** → wait 2 seconds, retry the mutation from 4.5.2 once, then re-verify.
+- **Still wrong after retry** → report: `"Issue #{N} created but parent linkage to #$parent_number failed. Retry manually: gh api graphql -H 'GraphQL-Features: sub_issues' -f query='mutation { addSubIssue(input: {issueId: \"$parent_node_id\", subIssueId: \"$issue_node_id\"}) { subIssue { number } } }'"`. Continue to 4.6 anyway — the issue exists.
+
+### 4.6 Archive the draft
+
+On successful post — i.e., the issue was created in 4.2, regardless of whether 4.3 (type-set), 4.4 (type-verify), and 4.5 (parent-link + verify) all succeeded. The issue exists; archival is unconditional once 4.2 returns a URL:
 
 ```bash
 ARCHIVE_DIR="$TRUNK_ROOT/.notes/.agents/_archive/issue-create"
@@ -532,9 +695,9 @@ Posted: {url}
 
 On **post failure** (`gh issue create` or Forgejo API failed) → draft stays in `drafts/`. Report the error and the draft path. User can retry by re-invoking `/issue-create` with the saved draft.
 
-On **type-set failure after retry** (4.4 returned null twice) → still archive the draft, since the issue exists. Include the manual-retry command in the user-facing report.
+On **type-set failure after retry** (4.4 returned null twice) or **parent-link failure after retry** (4.5.3 still mismatched after retry) → still archive the draft, since the issue exists. Include the relevant manual-retry command in the user-facing report.
 
-### 4.6 Report + handoff
+### 4.7 Report + handoff
 
 Show the user:
 
@@ -544,6 +707,7 @@ Show the user:
 Labels: {applied}
 Milestone: {applied or "—"}
 Project: {attached or "—"}
+Parent: {linked #N or "—" or "⚠ not linked, retry manually"}
 Type: {set or "—" or "⚠ not set, retry manually"}
 
 Archived draft: {archive path}
@@ -569,6 +733,10 @@ Then ask: "Start working on this now?" If yes, invoke the `issue-work` skill wit
 | User says "actually, let me think more" | Leave draft in `drafts/`; exit cleanly; re-invoke later picks up by listing drafts |
 | Dedup check finds identical title | Surface + ask — never auto-merge |
 | GraphQL rate-limited | Surface the rate-reset time from the response header; don't loop |
+| `sub_issues` preview disabled on the account | Stage 2.3.2 surfaces the error; ask `[yes / stop]` to continue without parent linkage |
+| Parent number user typed (`Specify a different parent`) doesn't exist | Skip linkage with a one-line note; issue still posts |
+| Convergence picks a closed parent | Offer it with `(closed)` in the option label; user decides |
+| User picks a parent in 2.3 but post fails in 4.2 | Draft retains `parent:` in frontmatter; re-invoking `/issue-create` resumes with the choice intact |
 
 ---
 
@@ -576,7 +744,7 @@ Then ask: "Start working on this now?" If yes, invoke the `issue-work` skill wit
 
 - **Edit existing issues.** (Separate skill if wanted.)
 - **Post to multiple repos at once.**
-- **Auto-link related issues/PRs.** (User can reference them in their answers — the draft preserves whatever they write.)
+- **Auto-link parent or related issues without confirmation.** Stage 2.3 always asks before linking; user can pick `No parent`. Free-text `#N` references in the body are preserved as-is, never auto-converted into linkages.
 - **Bulk-create issues from a list.**
 - **Assign anyone other than the default (caller is author, no assignees).**
 - **Add `Co-authored-by: Claude` trailers** to the issue body.

--- a/plugins/athena-notes/skills/issue-create/SKILL.md
+++ b/plugins/athena-notes/skills/issue-create/SKILL.md
@@ -308,7 +308,7 @@ One batched GraphQL request, one alias per candidate. Fetch each candidate's own
 aliases=""
 for n in "${candidates[@]}"; do
   [[ "$n" =~ ^[1-9][0-9]*$ ]] || continue
-  aliases+="i${n}: issue(number: ${n}) { number title state parent { number title url state } }
+  aliases+="i${n}: issue(number: ${n}) { number title state parent { number title state } }
 "
 done
 
@@ -325,7 +325,7 @@ gh api graphql \
   --jq '.data.repository | to_entries | map(select(.value != null)) | map({n: (.key | sub("^i"; "") | tonumber), self: {title: .value.title, state: .value.state}, parent: .value.parent})'
 ```
 
-The `--jq` filter drops `null` issues (a bad number returns `null` rather than an error) and reshapes the rest into `[{n, self: {title, state}, parent: {number, title, url, state} | null}, …]`.
+The `--jq` filter drops `null` issues (a bad number returns `null` rather than an error) and reshapes the rest into `[{n, self: {title, state}, parent: {number, title, state} | null}, …]`.
 
 If the call fails (non-zero exit, error in response — most commonly the `sub_issues` preview not enabled on the account, or rate limit), surface the error and ask: *"Parent search failed ({error}). Continue without inferred-parent suggestions? [yes / stop]"*. Treat silence or any non-`yes` reply as stop. On `yes`, **fall through to 2.3.4** — the "always prompt" invariant holds even in the failure path. Since the failed query was the source of titles and states, direct parents render as bare `Link under #N` (no `{title}`, no `(closed)` indicator), inferred-parent suggestions are dropped entirely, and `Specify a different parent` + `No parent` remain available as always.
 
@@ -342,7 +342,7 @@ Among candidates whose `n` is in `siblings[]` but **not** in `direct_parents[]`,
 Use `AskUserQuestion` single-select. Always include all of:
 
 - **Direct parents** (one option per `direct_parents[]` entry): `Link under #N — {title}`, with ` (closed)` appended when the candidate's own `self.state == "CLOSED"` — for direct parents, `self` *is* the parent. Listed first — the user named these explicitly, so they should not have to retype them via `Specify`.
-- **Inferred parents** from 2.3.3 (up to 3): same option shape, with ` (closed)` appended when the inferred parent's `parent.state == "CLOSED"` (the sibling's parent — a different object than `self`).
+- **Inferred parents** from 2.3.3 (up to 3): same option shape, with ` (closed)` appended when the inferred parent's `parent.state == "CLOSED"` (the sibling's parent — a different object than `self`). **Drop any inferred-parent number that already appears in `direct_parents[]`** — convergence can land on a number the user named directly, and showing it twice as `Link under #N — {title}` would be visually duplicative without conveying anything new.
 - `Specify a different parent` — on selection, ask a follow-up turn: *"Parent issue number? (e.g. `42`, or `skip`)"*. Validate the answer parses as a positive integer; on invalid input or `skip`, treat as `No parent`. Persist the typed number directly — Stage 4.5.3's verify step catches a non-existent or otherwise invalid parent on the post side. We deliberately don't pre-confirm or surface state at draft time; the user typed the number explicitly, and a closed-parent linkage is allowed.
 - `No parent` — default. The natural choice when no candidates surfaced or the user has none in mind.
 
@@ -635,6 +635,8 @@ Skip this stage entirely when:
 
 Otherwise, link the new issue under the chosen parent. Mirrors the 4.3+4.4 pattern: mutation, then verify, then one retry on failure.
 
+**Read `parent_number` from the draft frontmatter before doing anything else.** On a resume path (re-invoking `/issue-create` against a saved draft), the `parent:` field is the only place the choice persists across sessions — Stage 2.3.5 wrote it; Stage 4.5 reads it. The variable name `$parent_number` referenced below assumes this assignment has happened.
+
 #### 4.5.1 Resolve node IDs
 
 The new issue's node ID was already resolved in 4.3.2 as `$issue_node_id`. Reuse it (resolve it here if 4.3 was skipped, e.g. no-template path):
@@ -685,19 +687,19 @@ verified_parent=$(gh api graphql \
 
 - **Matches `$parent_number`** → success. Continue to 4.6 (Archive).
 - **Empty or mismatched** → wait 2 seconds, retry the mutation from 4.5.2 once, then re-verify.
-- **Still wrong after retry** → report (rendered in a fenced code block, not inline, so the user can copy without quote-mismatch):
+- **Still wrong after retry** → report a fenced code block with the actual `$parent_node_id` / `$issue_node_id` / `$N` values **substituted inline** before display (do not show literal `{parent_node_id}` placeholders — a user copy-pasting the rendered block must get a working command). The retry uses GraphQL variable binding (same shape as 4.5.2), not query-string interpolation, so quoting is straightforward:
 
   ````
-  Issue #{N} created but parent linkage to #{parent_number} failed. Retry manually:
+  Issue #<actual N> created but parent linkage to #<actual parent_number> failed. Retry manually:
 
       gh api graphql \
         -H 'GraphQL-Features: sub_issues' \
-        -f parentId='{parent_node_id}' \
-        -f childId='{issue_node_id}' \
+        -f parentId=<actual parent_node_id> \
+        -f childId=<actual issue_node_id> \
         -f query='mutation($parentId: ID!, $childId: ID!) { addSubIssue(input: {issueId: $parentId, subIssueId: $childId}) { subIssue { number } } }'
   ````
 
-  Substitute the bracketed values inline in the user-facing message. The retry uses GraphQL variable binding (same shape as 4.5.2) instead of inlining the IDs into the query string, so the command survives copy-paste without escaping pitfalls. Continue to 4.6 (Archive) anyway — the issue exists.
+  Continue to 4.6 (Archive) anyway — the issue exists.
 
 ### 4.6 Archive the draft
 

--- a/plugins/athena-notes/skills/issue-create/SKILL.md
+++ b/plugins/athena-notes/skills/issue-create/SKILL.md
@@ -245,7 +245,9 @@ Forgejo has no native sub-issue concept — skip this entire subsection silently
 
 #### 2.3.1 Build the candidate set
 
-Two sources, used differently. The batched GraphQL query in 2.3.2 interpolates these numbers directly into the alias list, so every value entering `direct_parents[]` or `siblings[]` must match `^[1-9][0-9]*$` — a strict positive-integer guard, no leading zeros, `0` excluded since GitHub issues start at 1. Apply the guard at the source for each loop:
+**Why two arrays.** Seed `#N` references go into `direct_parents[]` and become parent options directly in 2.3.4. Label-cluster siblings go into `siblings[]` and feed the convergence inference in 2.3.3 (their `parent` field is what we infer from). The two sources behave differently from 2.3.3 onward; keep them separate, then take their union for the single batched query in 2.3.2.
+
+The batched GraphQL query in 2.3.2 interpolates these numbers directly into the alias list, so every value entering `direct_parents[]` or `siblings[]` must match `^[1-9][0-9]*$` — a strict positive-integer guard, no leading zeros, `0` excluded since GitHub issues start at 1. Apply the guard at the source for each loop:
 
 1. **Seed `#N` references → `direct_parents[]`.** Scan the user's initial framing and Q&A answers for bare `#N` patterns (drop cross-repo `{owner}/{repo}#N` references — this skill only links within the target repo). The capture group must be the integer only; trailing characters from a loose regex would survive into the alias list. When someone says "follow-up to #656" the natural reading is that *#656 is the parent* — surface these directly as parent options in 2.3.4 rather than treating them as siblings to infer a parent from.
 
@@ -277,7 +279,23 @@ Two sources, used differently. The batched GraphQL query in 2.3.2 interpolates t
      --jq '.[].number')
    ```
 
-Build the de-duplicated query set: `candidates = direct_parents ∪ siblings`, with `direct_parents[]` entries kept first and `siblings[]` filling the remaining slots up to a total of 20 — this preserves the user-named numbers when a heavy label cluster would otherwise crowd them out. If `candidates` is empty → skip 2.3.2 and 2.3.3, jump to 2.3.4 (which still prompts, with only `Specify a different parent` and `No parent` available).
+Build the de-duplicated, capped query set. Order matters — `direct_parents[]` entries kept first so a heavy label cluster can't crowd out user-named numbers, then `siblings[]` filling the remaining slots up to a total of 20:
+
+```bash
+candidates=()
+for n in "${direct_parents[@]}" "${siblings[@]}"; do
+  # Skip if already added (dedup). Without this, a number in both arrays would
+  # produce duplicate GraphQL aliases (`i123:` twice) and the API rejects the
+  # whole batch with a parse error.
+  for existing in "${candidates[@]}"; do
+    [[ "$existing" == "$n" ]] && continue 2
+  done
+  candidates+=("$n")
+  (( ${#candidates[@]} >= 20 )) && break
+done
+```
+
+If `candidates` is empty → skip 2.3.2 and 2.3.3, jump to 2.3.4 (which still prompts, with only `Specify a different parent` and `No parent` available).
 
 #### 2.3.2 Query candidates
 
@@ -285,8 +303,11 @@ One batched GraphQL request, one alias per candidate. Fetch each candidate's own
 
 ```bash
 # 'i' prefix required — GraphQL alias names cannot start with a digit. Stripped in --jq via sub("^i"; "").
+# Defensive re-guard: 2.3.1's source-loop validation should have caught any non-integer,
+# but interpolating into a query string has zero error-recovery, so we re-check at the boundary.
 aliases=""
 for n in "${candidates[@]}"; do
+  [[ "$n" =~ ^[1-9][0-9]*$ ]] || continue
   aliases+="i${n}: issue(number: ${n}) { number title state parent { number title url state } }
 "
 done
@@ -306,7 +327,7 @@ gh api graphql \
 
 The `--jq` filter drops `null` issues (a bad number returns `null` rather than an error) and reshapes the rest into `[{n, self: {title, state}, parent: {number, title, url, state} | null}, …]`.
 
-If the call fails (non-zero exit, error in response — most commonly the `sub_issues` preview not enabled on the account, or rate limit), surface the error and ask: *"Parent search failed ({error}). Continue posting without parent linkage? [yes / stop]"*. Treat silence or any non-`yes` reply as stop. Do not silently fall through — same failure mode Stage 2.2 Project guards against.
+If the call fails (non-zero exit, error in response — most commonly the `sub_issues` preview not enabled on the account, or rate limit), surface the error and ask: *"Parent search failed ({error}). Continue without inferred-parent suggestions? [yes / stop]"*. Treat silence or any non-`yes` reply as stop. On `yes`, **fall through to 2.3.4** — the "always prompt" invariant holds even in the failure path. Since the failed query was the source of titles and states, direct parents render as bare `Link under #N` (no `{title}`, no `(closed)` indicator), inferred-parent suggestions are dropped entirely, and `Specify a different parent` + `No parent` remain available as always.
 
 #### 2.3.3 Find convergence (siblings only)
 
@@ -601,7 +622,7 @@ verified_type=$(gh api graphql -f query='
 
 `gh api --jq '... // ""'` turns a JSON `null` into an empty string, so a bash `[[ -z ... ]]` test is reliable. Do not test against the literal word `null` — an issue type literally named "null" would collide (unlikely but the `// ""` pattern is unambiguous either way).
 
-- **Non-empty** (returns a name) → success. Continue to 4.5.
+- **Non-empty** (returns a name) → success. Continue to 4.5 (Link parent).
 - **Empty** → wait 2 seconds, retry the mutation from 4.3.2 once, then re-verify.
 - **Still empty after retry** → report: "Issue #{N} created but type not set. Retry manually: `gh api graphql -f query='mutation { updateIssueIssueType(input: {issueId: \"$issue_node_id\", issueTypeId: \"$type_id\"}) { issue { issueType { name } } } }'`." Continue to 4.5 (Link parent) anyway — the issue exists.
 
@@ -664,7 +685,19 @@ verified_parent=$(gh api graphql \
 
 - **Matches `$parent_number`** → success. Continue to 4.6 (Archive).
 - **Empty or mismatched** → wait 2 seconds, retry the mutation from 4.5.2 once, then re-verify.
-- **Still wrong after retry** → report: `"Issue #{N} created but parent linkage to #$parent_number failed. Retry manually: gh api graphql -H 'GraphQL-Features: sub_issues' -f query='mutation { addSubIssue(input: {issueId: \"$parent_node_id\", subIssueId: \"$issue_node_id\"}) { subIssue { number } } }'"`. Continue to 4.6 (Archive) anyway — the issue exists.
+- **Still wrong after retry** → report (rendered in a fenced code block, not inline, so the user can copy without quote-mismatch):
+
+  ````
+  Issue #{N} created but parent linkage to #{parent_number} failed. Retry manually:
+
+      gh api graphql \
+        -H 'GraphQL-Features: sub_issues' \
+        -f parentId='{parent_node_id}' \
+        -f childId='{issue_node_id}' \
+        -f query='mutation($parentId: ID!, $childId: ID!) { addSubIssue(input: {issueId: $parentId, subIssueId: $childId}) { subIssue { number } } }'
+  ````
+
+  Substitute the bracketed values inline in the user-facing message. The retry uses GraphQL variable binding (same shape as 4.5.2) instead of inlining the IDs into the query string, so the command survives copy-paste without escaping pitfalls. Continue to 4.6 (Archive) anyway — the issue exists.
 
 ### 4.6 Archive the draft
 

--- a/plugins/athena-notes/skills/issue-create/SKILL.md
+++ b/plugins/athena-notes/skills/issue-create/SKILL.md
@@ -263,7 +263,10 @@ The batched GraphQL query in 2.3.2 interpolates these numbers directly into the 
    ```bash
    search_terms=""
    for l in "${selected_labels[@]}"; do
-     search_terms+=" label:\"$l\""
+     # Escape any embedded `"` in the label name so it can't break out of the quoted value
+     # in the search string and re-scope the query to a different repo.
+     l_escaped="${l//\"/\\\"}"
+     search_terms+=" label:\"$l_escaped\""
    done
    search_terms="${search_terms# }"
 
@@ -303,8 +306,6 @@ One batched GraphQL request, one alias per candidate. Fetch each candidate's own
 
 ```bash
 # 'i' prefix required — GraphQL alias names cannot start with a digit. Stripped in --jq via sub("^i"; "").
-# Defensive re-guard: 2.3.1's source-loop validation should have caught any non-integer,
-# but interpolating into a query string has zero error-recovery, so we re-check at the boundary.
 aliases=""
 for n in "${candidates[@]}"; do
   [[ "$n" =~ ^[1-9][0-9]*$ ]] || continue
@@ -312,6 +313,10 @@ for n in "${candidates[@]}"; do
 "
 done
 
+# Note: this `gh api graphql` call uses double-quotes around `-f query="..."` because
+# `$aliases` must expand. The other gh api graphql calls in this file (4.3, 4.4, 4.5.2,
+# 4.5.3) use single-quotes — those queries don't interpolate any shell variables. Don't
+# normalize the quoting style across the file: the asymmetry is load-bearing.
 gh api graphql \
   -H "GraphQL-Features: sub_issues" \
   -f query="
@@ -341,9 +346,10 @@ Among candidates whose `n` is in `siblings[]` but **not** in `direct_parents[]`,
 
 Use `AskUserQuestion` single-select. Always include all of:
 
-- **Direct parents** (one option per `direct_parents[]` entry): `Link under #N — {title}`, with ` (closed)` appended when the candidate's own `self.state == "CLOSED"` — for direct parents, `self` *is* the parent. Listed first — the user named these explicitly, so they should not have to retype them via `Specify`.
-- **Inferred parents** from 2.3.3 (up to 3): same option shape, with ` (closed)` appended when the inferred parent's `parent.state == "CLOSED"` (the sibling's parent — a different object than `self`). **Drop any inferred-parent number that already appears in `direct_parents[]`** — convergence can land on a number the user named directly, and showing it twice as `Link under #N — {title}` would be visually duplicative without conveying anything new.
-- `Specify a different parent` — on selection, ask a follow-up turn: *"Parent issue number? (e.g. `42`, or `skip`)"*. Validate the answer parses as a positive integer; on invalid input or `skip`, treat as `No parent`. Persist the typed number directly — Stage 4.5.3's verify step catches a non-existent or otherwise invalid parent on the post side. We deliberately don't pre-confirm or surface state at draft time; the user typed the number explicitly, and a closed-parent linkage is allowed.
+- **Direct parents** (one option per `direct_parents[]` entry): `Link under #N — {title}`. Listed first — the user named these explicitly, so they should not have to retype them via `Specify`.
+- **Inferred parents** from 2.3.3 (up to 3): same option shape. **Drop any inferred-parent number that already appears in `direct_parents[]`** — convergence can land on a number the user named directly, and showing it twice as `Link under #N — {title}` would be visually duplicative without conveying anything new.
+- Append ` (closed)` to either option label when the parent issue is closed. Field path differs by source: direct parents use `self.state` (the candidate *is* the parent); inferred parents use the sibling's `parent.state` (a different object).
+- `Specify a different parent` — on selection, ask a follow-up turn: *"Parent issue number? (e.g. `42`, or `skip`)"*. Validate the answer parses as a positive integer; on invalid input or `skip`, surface a brief inline note (`"Input not recognized — treating as No parent."`) and continue with `parent` empty. Persist the typed number directly — Stage 4.5.3's verify step catches a non-existent or otherwise invalid parent on the post side. We deliberately don't pre-confirm or surface state at draft time; the user typed the number explicitly, and a closed-parent linkage is allowed.
 - `No parent` — default. The natural choice when no candidates surfaced or the user has none in mind.
 
 Capture the result as a single integer (parent issue number) or empty.
@@ -479,16 +485,17 @@ milestone_flag=()
 project_flag=()
 [[ -n "$project" ]] && project_flag=(--project "$project")
 
-gh issue create \
+issue_url=$(gh issue create \
   --repo "$owner/$repo" \
   --title "$title" \
   --body-file "$BODY_FILE" \
   "${label_flags[@]}" \
   "${milestone_flag[@]}" \
-  "${project_flag[@]}"
+  "${project_flag[@]}")
+new_issue_number=$(echo "$issue_url" | grep -oE '[0-9]+$')
 ```
 
-The command prints the new issue URL on success. Capture it.
+`$issue_url` and `$new_issue_number` are both used downstream — 4.3.2 / 4.4 / 4.5.1 all assume `$new_issue_number` is set, including the no-template path that skips 4.3 entirely.
 
 **Forgejo:**
 
@@ -624,7 +631,18 @@ verified_type=$(gh api graphql -f query='
 
 - **Non-empty** (returns a name) → success. Continue to 4.5 (Link parent).
 - **Empty** → wait 2 seconds, retry the mutation from 4.3.2 once, then re-verify.
-- **Still empty after retry** → report: "Issue #{N} created but type not set. Retry manually: `gh api graphql -f query='mutation { updateIssueIssueType(input: {issueId: \"$issue_node_id\", issueTypeId: \"$type_id\"}) { issue { issueType { name } } } }'`." Continue to 4.5 (Link parent) anyway — the issue exists.
+- **Still empty after retry** → report a fenced code block with the actual `$issue_node_id` / `$type_id` / `$N` values **substituted inline** before display (do not show literal `{issue_node_id}` placeholders — a user copy-pasting the rendered block must get a working command):
+
+  ````
+  Issue #<actual N> created but type not set. Retry manually:
+
+      gh api graphql \
+        -f issueId=<actual issue_node_id> \
+        -f typeId=<actual type_id> \
+        -f query='mutation($issueId: ID!, $typeId: ID!) { updateIssueIssueType(input: {issueId: $issueId, issueTypeId: $typeId}) { issue { issueType { name } } } }'
+  ````
+
+  Continue to 4.5 (Link parent) anyway — the issue exists.
 
 ### 4.5 Link parent issue (GitHub only, when `parent` set in 2.3)
 
@@ -635,7 +653,7 @@ Skip this stage entirely when:
 
 Otherwise, link the new issue under the chosen parent. Mirrors the 4.3+4.4 pattern: mutation, then verify, then one retry on failure.
 
-**Read `parent_number` from the draft frontmatter before doing anything else.** On a resume path (re-invoking `/issue-create` against a saved draft), the `parent:` field is the only place the choice persists across sessions — Stage 2.3.5 wrote it; Stage 4.5 reads it. The variable name `$parent_number` referenced below assumes this assignment has happened.
+**Read `parent_number` from the draft frontmatter before doing anything else.** On a resume path (re-invoking `/issue-create` against a saved draft), the `parent:` field is the only place the choice persists across sessions — Stage 2.3.5 wrote it; Stage 4.5 reads it. Re-validate that `$parent_number` matches `^[1-9][0-9]*$` after reading; if it fails (e.g., a hand-edited draft has `parent: "evil"` or `parent: 0`), treat as `No parent` and skip to 4.6.
 
 #### 4.5.1 Resolve node IDs
 
@@ -680,14 +698,14 @@ verified_parent=$(gh api graphql \
       }
     }
   ' -f owner="$owner" -f repo="$repo" -F number="$new_issue_number" \
-    --jq '.data.repository.issue.parent.number // ""')
+    --jq '.data.repository.issue.parent.number // "" | tostring')
 ```
 
 `// ""` turns a JSON `null` into an empty string (same pattern as 4.4) so `[[ -z ... ]]` is reliable.
 
 - **Matches `$parent_number`** → success. Continue to 4.6 (Archive).
 - **Empty or mismatched** → wait 2 seconds, retry the mutation from 4.5.2 once, then re-verify.
-- **Still wrong after retry** → report a fenced code block with the actual `$parent_node_id` / `$issue_node_id` / `$N` values **substituted inline** before display (do not show literal `{parent_node_id}` placeholders — a user copy-pasting the rendered block must get a working command). The retry uses GraphQL variable binding (same shape as 4.5.2), not query-string interpolation, so quoting is straightforward:
+- **Still wrong after retry** → report a fenced code block with the actual `$parent_node_id` / `$issue_node_id` / `$N` values **substituted inline** before display (do not show literal `{parent_node_id}` placeholders — a user copy-pasting the rendered block must get a working command):
 
   ````
   Issue #<actual N> created but parent linkage to #<actual parent_number> failed. Retry manually:
@@ -761,8 +779,7 @@ Then ask: "Start working on this now?" If yes, invoke the `issue-work` skill wit
 | User says "actually, let me think more" | Leave draft in `drafts/`; exit cleanly; re-invoke later picks up by listing drafts |
 | Dedup check finds identical title | Surface + ask — never auto-merge |
 | GraphQL rate-limited | Surface the rate-reset time from the response header; don't loop |
-| `sub_issues` preview disabled on the account | Stage 2.3.2 surfaces the error; ask `[yes / stop]` to continue without parent linkage |
-| Parent number user typed (`Specify a different parent`) is invalid (non-integer, `skip`, or empty) | Treat as `No parent` silently; `parent:` stays empty in the draft |
+| Parent number user typed (`Specify a different parent`) is invalid (non-integer, `skip`, or empty) | Surface `Input not recognized — treating as No parent.` and continue; `parent:` stays empty in the draft |
 | Confirmed parent number is valid at draft time but doesn't exist (or is inaccessible) at post time | Stage 4.5.1 reports `"Parent #N lookup failed — skipping linkage."` and continues to 4.6; the issue still posts |
 | Convergence picks a closed parent | Offer it with `(closed)` in the option label; user decides |
 | User picks a parent in 2.3 but post fails in 4.2 | Draft retains `parent:` in frontmatter; re-invoking `/issue-create` resumes with the choice intact |

--- a/plugins/athena-notes/skills/issue-create/SKILL.md
+++ b/plugins/athena-notes/skills/issue-create/SKILL.md
@@ -249,13 +249,14 @@ Forgejo has no native sub-issue concept — skip this entire subsection silently
 
 The batched GraphQL query in 2.3.2 interpolates these numbers directly into the alias list, so every value entering `direct_parents[]` or `siblings[]` must match `^[1-9][0-9]*$` — a strict positive-integer guard, no leading zeros, `0` excluded since GitHub issues start at 1. Apply the guard at the source for each loop:
 
-1. **Seed `#N` references → `direct_parents[]`.** Scan the user's initial framing and Q&A answers for bare `#N` patterns (drop cross-repo `{owner}/{repo}#N` references — this skill only links within the target repo). The capture group must be the integer only; trailing characters from a loose regex would survive into the alias list. When someone says "follow-up to #656" the natural reading is that *#656 is the parent* — surface these directly as parent options in 2.3.4 rather than treating them as siblings to infer a parent from.
+1. **Seed `#N` references → `direct_parents[]`.** Scan the user's initial framing and any `#N` references that surfaced during the Stage 2 Q&A for bare `#N` patterns (drop cross-repo `{owner}/{repo}#N` references — this skill only links within the target repo). The capture group must be the integer only; trailing characters from a loose regex would survive into the alias list. When someone says "follow-up to #656" the natural reading is that *#656 is the parent* — surface these directly as parent options in 2.3.4 rather than treating them as siblings to infer a parent from.
 
    ```bash
+   # $seed_text is the initial framing concatenated with every Q&A answer that may carry an #N reference.
    direct_parents=()
    while read -r n; do
      [[ "$n" =~ ^[1-9][0-9]*$ ]] && direct_parents+=("$n")
-   done < <(printf '%s\n' "$user_seed_text" | grep -oE '(^|[^/A-Za-z0-9_-])#[0-9]+' | grep -oE '[0-9]+')
+   done < <(printf '%s\n' "$seed_text" | grep -oE '(^|[^/A-Za-z0-9_-])#[0-9]+' | grep -oE '[0-9]+')
    ```
 
 2. **Label-cluster siblings → `siblings[]`.** Open issues in the target repo that share **all** selected labels (full intersection). Skipped if no labels were selected in 2.2 — full-intersection on zero labels matches every open issue, which is noise. The `gh issue list --json number` output is already integer-typed, but the same regex guard applies on the way in:
@@ -263,9 +264,11 @@ The batched GraphQL query in 2.3.2 interpolates these numbers directly into the 
    ```bash
    search_terms=""
    for l in "${selected_labels[@]}"; do
-     # Escape any embedded `"` in the label name so it can't break out of the quoted value
-     # in the search string and re-scope the query to a different repo.
-     l_escaped="${l//\"/\\\"}"
+     # Escape any embedded `\` then `"` in the label name so the value can't break out of the
+     # search string and re-scope the query to a different repo. Backslash must come first;
+     # otherwise the escape we add for `"` would itself get escaped on a second pass.
+     l_escaped="${l//\\/\\\\}"
+     l_escaped="${l_escaped//\"/\\\"}"
      search_terms+=" label:\"$l_escaped\""
    done
    search_terms="${search_terms# }"
@@ -287,9 +290,8 @@ Build the de-duplicated, capped query set. Order matters — `direct_parents[]` 
 ```bash
 candidates=()
 for n in "${direct_parents[@]}" "${siblings[@]}"; do
-  # Skip if already added (dedup). Without this, a number in both arrays would
-  # produce duplicate GraphQL aliases (`i123:` twice) and the API rejects the
-  # whole batch with a parse error.
+  # Without dedup, a number in both arrays produces duplicate GraphQL aliases (`i123:` twice)
+  # and the API rejects the whole batch with a parse error.
   for existing in "${candidates[@]}"; do
     [[ "$existing" == "$n" ]] && continue 2
   done
@@ -316,7 +318,9 @@ done
 # Note: this `gh api graphql` call uses double-quotes around `-f query="..."` because
 # `$aliases` must expand. The other gh api graphql calls in this file (4.3, 4.4, 4.5.2,
 # 4.5.3) use single-quotes — those queries don't interpolate any shell variables. Don't
-# normalize the quoting style across the file: the asymmetry is load-bearing.
+# normalize the quoting style across the file: switching this block to single-quotes
+# turns `$aliases` into a literal field name and the GraphQL parser rejects the whole
+# query at the first alias boundary.
 gh api graphql \
   -H "GraphQL-Features: sub_issues" \
   -f query="
@@ -631,7 +635,7 @@ verified_type=$(gh api graphql -f query='
 
 - **Non-empty** (returns a name) → success. Continue to 4.5 (Link parent).
 - **Empty** → wait 2 seconds, retry the mutation from 4.3.2 once, then re-verify.
-- **Still empty after retry** → report a fenced code block with the actual `$issue_node_id` / `$type_id` / `$N` values **substituted inline** before display (do not show literal `{issue_node_id}` placeholders — a user copy-pasting the rendered block must get a working command):
+- **Still empty after retry** → report a fenced code block with the actual `$issue_node_id` / `$type_id` / `$N` values **substituted inline** before display:
 
   ````
   Issue #<actual N> created but type not set. Retry manually:
@@ -705,7 +709,7 @@ verified_parent=$(gh api graphql \
 
 - **Matches `$parent_number`** → success. Continue to 4.6 (Archive).
 - **Empty or mismatched** → wait 2 seconds, retry the mutation from 4.5.2 once, then re-verify.
-- **Still wrong after retry** → report a fenced code block with the actual `$parent_node_id` / `$issue_node_id` / `$N` values **substituted inline** before display (do not show literal `{parent_node_id}` placeholders — a user copy-pasting the rendered block must get a working command):
+- **Still wrong after retry** → report a fenced code block with the actual `$parent_node_id` / `$issue_node_id` / `$N` values **substituted inline** before display:
 
   ````
   Issue #<actual N> created but parent linkage to #<actual parent_number> failed. Retry manually:

--- a/plugins/athena-notes/skills/issue-create/SKILL.md
+++ b/plugins/athena-notes/skills/issue-create/SKILL.md
@@ -245,11 +245,18 @@ Forgejo has no native sub-issue concept — skip this entire subsection silently
 
 #### 2.3.1 Build the candidate set
 
-Two sources, used differently. **In each loop, drop any value that fails `[[ "$n" =~ ^[0-9]+$ ]]` before it lands in the array** — the batched GraphQL query in 2.3.2 interpolates these numbers directly into the alias list, so a non-integer value here is a query-injection vector. Validate at the source, not at the union.
+Two sources, used differently. The batched GraphQL query in 2.3.2 interpolates these numbers directly into the alias list, so every value entering `direct_parents[]` or `siblings[]` must match `^[1-9][0-9]*$` — a strict positive-integer guard, no leading zeros, `0` excluded since GitHub issues start at 1. Apply the guard at the source for each loop:
 
-1. **Seed `#N` references → `direct_parents[]`.** Scan the user's initial framing and Q&A answers for bare `#N` patterns (drop cross-repo `{owner}/{repo}#N` references — this skill only links within the target repo). For each match, push the captured number onto `direct_parents[]` only if it passes the positive-integer regex; otherwise drop it. When someone says "follow-up to #656" the natural reading is that *#656 is the parent* — surface these directly as parent options in 2.3.4 rather than treating them as siblings to infer a parent from.
+1. **Seed `#N` references → `direct_parents[]`.** Scan the user's initial framing and Q&A answers for bare `#N` patterns (drop cross-repo `{owner}/{repo}#N` references — this skill only links within the target repo). The capture group must be the integer only; trailing characters from a loose regex would survive into the alias list. When someone says "follow-up to #656" the natural reading is that *#656 is the parent* — surface these directly as parent options in 2.3.4 rather than treating them as siblings to infer a parent from.
 
-2. **Label-cluster siblings → `siblings[]`.** Open issues in the target repo that share **all** selected labels (full intersection). Skipped if no labels were selected in 2.2 — full-intersection on zero labels matches every open issue, which is noise. The `gh issue list --json number` output is already integer-typed, but pipe each line through the same regex guard before pushing onto `siblings[]` so the validation invariant is maintained at every entry point to the candidate set.
+   ```bash
+   direct_parents=()
+   while read -r n; do
+     [[ "$n" =~ ^[1-9][0-9]*$ ]] && direct_parents+=("$n")
+   done < <(printf '%s\n' "$user_seed_text" | grep -oE '(^|[^/A-Za-z0-9_-])#[0-9]+' | grep -oE '[0-9]+')
+   ```
+
+2. **Label-cluster siblings → `siblings[]`.** Open issues in the target repo that share **all** selected labels (full intersection). Skipped if no labels were selected in 2.2 — full-intersection on zero labels matches every open issue, which is noise. The `gh issue list --json number` output is already integer-typed, but the same regex guard applies on the way in:
 
    ```bash
    search_terms=""
@@ -258,16 +265,19 @@ Two sources, used differently. **In each loop, drop any value that fails `[[ "$n
    done
    search_terms="${search_terms# }"
 
-   gh issue list \
+   siblings=()
+   while read -r n; do
+     [[ "$n" =~ ^[1-9][0-9]*$ ]] && siblings+=("$n")
+   done < <(gh issue list \
      --repo "$owner/$repo" \
      --state open \
      --search "$search_terms" \
      --limit 20 \
      --json number \
-     --jq '.[].number'
+     --jq '.[].number')
    ```
 
-Build the de-duplicated query set: `candidates = direct_parents ∪ siblings`. Cap at 20. If `candidates` is empty → skip 2.3.2 and 2.3.3, jump to 2.3.4 (still prompt, with `(no candidates detected)`).
+Build the de-duplicated query set: `candidates = direct_parents ∪ siblings`, with `direct_parents[]` entries kept first and `siblings[]` filling the remaining slots up to a total of 20 — this preserves the user-named numbers when a heavy label cluster would otherwise crowd them out. If `candidates` is empty → skip 2.3.2 and 2.3.3, jump to 2.3.4 (which still prompts, with only `Specify a different parent` and `No parent` available).
 
 #### 2.3.2 Query candidates
 
@@ -310,8 +320,8 @@ Among candidates whose `n` is in `siblings[]` but **not** in `direct_parents[]`,
 
 Use `AskUserQuestion` single-select. Always include all of:
 
-- **Direct parents** (one option per `direct_parents[]` entry): `Link under #N — {title}` or `Link under #N — {title} (closed)` when `self.state == "CLOSED"`. Listed first — the user named these explicitly, so they should not have to retype them via `Specify`.
-- **Inferred parents** from 2.3.3 (up to 3): same option shape, ` (closed)` when the parent's `state == "CLOSED"`.
+- **Direct parents** (one option per `direct_parents[]` entry): `Link under #N — {title}`, with ` (closed)` appended when the candidate's own `self.state == "CLOSED"` — for direct parents, `self` *is* the parent. Listed first — the user named these explicitly, so they should not have to retype them via `Specify`.
+- **Inferred parents** from 2.3.3 (up to 3): same option shape, with ` (closed)` appended when the inferred parent's `parent.state == "CLOSED"` (the sibling's parent — a different object than `self`).
 - `Specify a different parent` — on selection, ask a follow-up turn: *"Parent issue number? (e.g. `42`, or `skip`)"*. Validate the answer parses as a positive integer; on invalid input or `skip`, treat as `No parent`. Persist the typed number directly — Stage 4.5.3's verify step catches a non-existent or otherwise invalid parent on the post side. We deliberately don't pre-confirm or surface state at draft time; the user typed the number explicitly, and a closed-parent linkage is allowed.
 - `No parent` — default. The natural choice when no candidates surfaced or the user has none in mind.
 
@@ -613,7 +623,7 @@ The new issue's node ID was already resolved in 4.3.2 as `$issue_node_id`. Reuse
 parent_node_id=$(gh api "repos/$owner/$repo/issues/$parent_number" --jq '.node_id')
 ```
 
-If `parent_node_id` is empty (404 on a missing issue, or any other error — `gh` will have printed the cause to stderr), report `"Parent #$parent_number lookup failed — skipping linkage."` and continue to 4.6 without linking. The issue exists; we'd rather skip the link with a visible reason than swallow auth/network errors as if they were "parent not found."
+If `parent_node_id` is empty (404 on a missing issue, or any other error — `gh` will have printed the cause to stderr), report `"Parent #$parent_number lookup failed — skipping linkage."` and continue to 4.6 (Archive) without linking. The issue exists; we'd rather skip the link with a visible reason than swallow auth/network errors as if they were "parent not found."
 
 #### 4.5.2 Call addSubIssue
 
@@ -652,9 +662,9 @@ verified_parent=$(gh api graphql \
 
 `// ""` turns a JSON `null` into an empty string (same pattern as 4.4) so `[[ -z ... ]]` is reliable.
 
-- **Matches `$parent_number`** → success. Continue to 4.6.
+- **Matches `$parent_number`** → success. Continue to 4.6 (Archive).
 - **Empty or mismatched** → wait 2 seconds, retry the mutation from 4.5.2 once, then re-verify.
-- **Still wrong after retry** → report: `"Issue #{N} created but parent linkage to #$parent_number failed. Retry manually: gh api graphql -H 'GraphQL-Features: sub_issues' -f query='mutation { addSubIssue(input: {issueId: \"$parent_node_id\", subIssueId: \"$issue_node_id\"}) { subIssue { number } } }'"`. Continue to 4.6 anyway — the issue exists.
+- **Still wrong after retry** → report: `"Issue #{N} created but parent linkage to #$parent_number failed. Retry manually: gh api graphql -H 'GraphQL-Features: sub_issues' -f query='mutation { addSubIssue(input: {issueId: \"$parent_node_id\", subIssueId: \"$issue_node_id\"}) { subIssue { number } } }'"`. Continue to 4.6 (Archive) anyway — the issue exists.
 
 ### 4.6 Archive the draft
 

--- a/plugins/athena-notes/skills/issue-create/SKILL.md
+++ b/plugins/athena-notes/skills/issue-create/SKILL.md
@@ -245,22 +245,18 @@ Forgejo has no native sub-issue concept — skip this entire subsection silently
 
 #### 2.3.1 Build the candidate set
 
-Combine two sources:
+Two sources, used differently:
 
-1. **Seed `#N` references.** Scan the user's initial framing and Q&A answers for bare `#N` patterns. Drop any cross-repo `{owner}/{repo}#N` references — this skill only links within the target repo. Capture the bare numbers.
+1. **Seed `#N` references → `direct_parents[]`.** Scan the user's initial framing and Q&A answers for bare `#N` patterns (drop cross-repo `{owner}/{repo}#N` references — this skill only links within the target repo). When someone says "follow-up to #656" the natural reading is that *#656 is the parent* — surface these directly as parent options in 2.3.4 rather than treating them as siblings to infer a parent from.
 
-2. **Label-cluster siblings.** Open issues in the target repo that share **all** selected labels (full intersection). Build the search query explicitly so label semantics are unambiguous (`gh issue list --label` repetition is AND in current `gh` versions, but `--search` makes the intent local to this file):
+2. **Label-cluster siblings → `siblings[]`.** Open issues in the target repo that share **all** selected labels (full intersection). Skipped if no labels were selected in 2.2 — full-intersection on zero labels matches every open issue, which is noise.
 
    ```bash
    search_terms=""
    for l in "${selected_labels[@]}"; do
-     if [[ "$l" == *" "* ]]; then
-       search_terms+=" label:\"$l\""
-     else
-       search_terms+=" label:$l"
-     fi
+     search_terms+=" label:\"$l\""
    done
-   search_terms="${search_terms# }"  # trim leading space
+   search_terms="${search_terms# }"
 
    gh issue list \
      --repo "$owner/$repo" \
@@ -271,29 +267,19 @@ Combine two sources:
      --jq '.[].number'
    ```
 
-   If no labels were selected in 2.2, skip the label-cluster source entirely — full-intersection on zero labels matches every open issue, which is noise.
+**Validate** every value in both arrays as a positive integer (`[[ "$n" =~ ^[0-9]+$ ]]`) before they reach 2.3.2. The batched GraphQL query in 2.3.2 interpolates these numbers directly into the alias list; a non-integer value would be a query-injection vector. Drop anything that fails the regex.
 
-Merge the two sources, dedupe, and exclude any number the user already named as the parent in their seed (e.g. "this is a follow-up to #656" — `#656` is the candidate parent, not a sibling). Cap the merged set at 20.
+Build the de-duplicated query set: `candidates = direct_parents ∪ siblings`. Cap at 20. If `candidates` is empty → skip 2.3.2 and 2.3.3, jump to 2.3.4 (still prompt, with `(no candidates detected)`).
 
-If the merged set is empty → skip 2.3.2 and 2.3.3, jump to 2.3.4 (still prompt, with `(no candidates detected)`).
+#### 2.3.2 Query candidates
 
-#### 2.3.2 Query each candidate's parent
-
-One batched GraphQL request, with one alias per candidate. The `sub_issues` preview header is required for both the read here and the mutation in Stage 4.5; without it the `parent` field returns `Field 'parent' doesn't exist on type 'Issue'`.
+One batched GraphQL request, one alias per candidate. Fetch each candidate's own `state` + `title` (used to render direct parents as options) and its `parent { … }` (used to derive convergence among siblings). Without `-H "GraphQL-Features: sub_issues"` the `parent` field returns `Field 'parent' doesn't exist on type 'Issue'`.
 
 ```bash
-# Build the alias list dynamically. Example shape:
-#   query($owner: String!, $repo: String!) {
-#     repository(owner: $owner, name: $repo) {
-#       i123: issue(number: 123) { parent { number title url state } }
-#       i456: issue(number: 456) { parent { number title url state } }
-#       ...
-#     }
-#   }
-
+# 'i' prefix is stripped by --jq's sub("^i"; "") below — keep in sync if it ever changes.
 aliases=""
 for n in "${candidates[@]}"; do
-  aliases+="i${n}: issue(number: ${n}) { parent { number title url state } }
+  aliases+="i${n}: issue(number: ${n}) { number title state parent { number title url state } }
 "
 done
 
@@ -307,29 +293,34 @@ gh api graphql \
     }
   " \
   -f owner="$owner" -f repo="$repo" \
-  --jq '.data.repository | to_entries | map(select(.value != null and .value.parent != null)) | map({sibling: (.key | sub("^i"; "") | tonumber), parent: .value.parent})'
+  --jq '.data.repository | to_entries | map(select(.value != null)) | map({n: (.key | sub("^i"; "") | tonumber), self: {title: .value.title, state: .value.state}, parent: .value.parent})'
 ```
 
-The `--jq` filter drops candidates with `null` parents (and any `null` issues — a bad number in the input set returns `null` rather than an error) and reshapes the rest into `[{sibling, parent: {number, title, url, state}}, …]`.
+The `--jq` filter drops `null` issues (a bad number returns `null` rather than an error) and reshapes the rest into `[{n, self: {title, state}, parent: {number, title, url, state} | null}, …]`.
 
-If the GraphQL call itself fails (non-zero exit, error in response — most commonly the `sub_issues` preview not enabled on the account, or rate limit), surface the error and ask: *"Parent search failed ({error}). Continue posting without parent linkage? [yes / stop]"*. Treat silence or any non-`yes` reply as stop. Do not silently fall through — that's the same failure mode Stage 2.2 Project guards against.
+If the call fails (non-zero exit, error in response — most commonly the `sub_issues` preview not enabled on the account, or rate limit), surface the error and ask: *"Parent search failed ({error}). Continue posting without parent linkage? [yes / stop]"*. Treat silence or any non-`yes` reply as stop. Do not silently fall through — same failure mode Stage 2.2 Project guards against.
 
-#### 2.3.3 Find convergence
+#### 2.3.3 Find convergence (siblings only)
 
-Tally parent numbers across the surviving candidates:
+Among candidates whose `n` is in `siblings[]` but **not** in `direct_parents[]`, tally the non-null `parent.number` values:
 
-- **Single agreed parent** (all non-null candidates point to the same parent) → primary suggestion.
-- **Mixed parents** → sort by count descending; take up to 3 distinct parents as suggestions, primary first.
-- **All candidates had `null` parent** → no suggestions; fall through to 2.3.4 with `(no parent detected among siblings)`.
-
-For each surfaced parent, append ` (closed)` to the option label when the parent's `state == "CLOSED"` so the user sees the state without an extra click.
+- **Single agreed parent** (all non-null sibling parents converge on one number) → primary inferred suggestion.
+- **Mixed parents** → sort by count descending; take up to 3 distinct parents as inferred suggestions.
+- **All sibling parents are `null`** → no inferred suggestions; only direct parents (if any) reach 2.3.4.
 
 #### 2.3.4 Ask the user
 
 Use `AskUserQuestion` single-select. Always include all of:
 
-- One option per surfaced candidate parent (up to 3): `Link under #N — {title}` or `Link under #N — {title} (closed)`.
-- `Specify a different parent` — on selection, ask a follow-up turn: *"Parent issue number? (e.g. `42`, or `skip`)"*. Validate the answer parses as a positive integer; on invalid input or `skip`, treat as `No parent`.
+- **Direct parents** (one option per `direct_parents[]` entry): `Link under #N — {title}` or `Link under #N — {title} (closed)` when `self.state == "CLOSED"`. Listed first — the user named these explicitly, so they should not have to retype them via `Specify`.
+- **Inferred parents** from 2.3.3 (up to 3): same option shape, ` (closed)` when the parent's `state == "CLOSED"`.
+- `Specify a different parent` — on selection, ask a follow-up turn: *"Parent issue number? (e.g. `42`, or `skip`)"*. Validate the answer parses as a positive integer; on invalid input or `skip`, treat as `No parent`. Then look up the typed number's title + state and confirm before persisting:
+
+  ```bash
+  parent_meta=$(gh api "repos/$owner/$repo/issues/$specified_n" --jq '{title, state}')
+  ```
+
+  Surface a confirmation prompt: *"Link under #{specified_n} — {title} ({state})?"*. On `no`, an empty `parent_meta` (404), or any error, treat as `No parent`. This keeps the closed-state visibility symmetric with the direct-parent and convergence paths.
 - `No parent` — default. The natural choice when no candidates surfaced or the user has none in mind.
 
 Capture the result as a single integer (parent issue number) or empty.
@@ -627,10 +618,10 @@ The new issue's node ID was already resolved in 4.3.2 as `$issue_node_id`. Reuse
 
 ```bash
 [[ -z "$issue_node_id" ]] && issue_node_id=$(gh api "repos/$owner/$repo/issues/$new_issue_number" --jq '.node_id')
-parent_node_id=$(gh api "repos/$owner/$repo/issues/$parent_number" --jq '.node_id' 2>/dev/null)
+parent_node_id=$(gh api "repos/$owner/$repo/issues/$parent_number" --jq '.node_id')
 ```
 
-If the parent number doesn't exist (404, empty `parent_node_id`), report `"Parent #$parent_number not found in $owner/$repo — skipping linkage."` and continue to 4.6 without linking. The issue exists; the orphaned parent number is a user mistake, not a posting failure.
+If `parent_node_id` is empty (404 on a missing issue, or any other error — `gh` will have printed the cause to stderr), report `"Parent #$parent_number lookup failed — skipping linkage."` and continue to 4.6 without linking. The issue exists; we'd rather skip the link with a visible reason than swallow auth/network errors as if they were "parent not found."
 
 #### 4.5.2 Call addSubIssue
 

--- a/plugins/athena-notes/skills/issue-create/SKILL.md
+++ b/plugins/athena-notes/skills/issue-create/SKILL.md
@@ -252,7 +252,6 @@ The batched GraphQL query in 2.3.2 interpolates these numbers directly into the 
 1. **Seed `#N` references → `direct_parents[]`.** Scan the user's initial framing and any `#N` references that surfaced during the Stage 2 Q&A for bare `#N` patterns (drop cross-repo `{owner}/{repo}#N` references — this skill only links within the target repo). The capture group must be the integer only; trailing characters from a loose regex would survive into the alias list. When someone says "follow-up to #656" the natural reading is that *#656 is the parent* — surface these directly as parent options in 2.3.4 rather than treating them as siblings to infer a parent from.
 
    ```bash
-   # $seed_text is the initial framing concatenated with every Q&A answer that may carry an #N reference.
    direct_parents=()
    while read -r n; do
      [[ "$n" =~ ^[1-9][0-9]*$ ]] && direct_parents+=("$n")
@@ -315,12 +314,8 @@ for n in "${candidates[@]}"; do
 "
 done
 
-# Note: this `gh api graphql` call uses double-quotes around `-f query="..."` because
-# `$aliases` must expand. The other gh api graphql calls in this file (4.3, 4.4, 4.5.2,
-# 4.5.3) use single-quotes — those queries don't interpolate any shell variables. Don't
-# normalize the quoting style across the file: switching this block to single-quotes
-# turns `$aliases` into a literal field name and the GraphQL parser rejects the whole
-# query at the first alias boundary.
+# Double-quotes required around `-f query="..."` so $aliases expands; single-quotes would
+# pass it as a literal field name and GraphQL parses-fails at the first alias boundary.
 gh api graphql \
   -H "GraphQL-Features: sub_issues" \
   -f query="
@@ -353,7 +348,7 @@ Use `AskUserQuestion` single-select. Always include all of:
 - **Direct parents** (one option per `direct_parents[]` entry): `Link under #N — {title}`. Listed first — the user named these explicitly, so they should not have to retype them via `Specify`.
 - **Inferred parents** from 2.3.3 (up to 3): same option shape. **Drop any inferred-parent number that already appears in `direct_parents[]`** — convergence can land on a number the user named directly, and showing it twice as `Link under #N — {title}` would be visually duplicative without conveying anything new.
 - Append ` (closed)` to either option label when the parent issue is closed. Field path differs by source: direct parents use `self.state` (the candidate *is* the parent); inferred parents use the sibling's `parent.state` (a different object).
-- `Specify a different parent` — on selection, ask a follow-up turn: *"Parent issue number? (e.g. `42`, or `skip`)"*. Validate the answer parses as a positive integer; on invalid input or `skip`, surface a brief inline note (`"Input not recognized — treating as No parent."`) and continue with `parent` empty. Persist the typed number directly — Stage 4.5.3's verify step catches a non-existent or otherwise invalid parent on the post side. We deliberately don't pre-confirm or surface state at draft time; the user typed the number explicitly, and a closed-parent linkage is allowed.
+- `Specify a different parent` — on selection, ask a follow-up turn: *"Parent issue number? (e.g. `42`, or `skip`)"*. Validate the answer parses as a positive integer; on invalid input or `skip`, surface a brief inline note (`"Input not recognized — treating as No parent."`) and continue with `parent` empty. Persist the typed number directly — Stage 4.5.3's verify step catches a non-existent parent on the post side, and a closed-parent linkage is allowed.
 - `No parent` — default. The natural choice when no candidates surfaced or the user has none in mind.
 
 Capture the result as a single integer (parent issue number) or empty.
@@ -705,11 +700,11 @@ verified_parent=$(gh api graphql \
     --jq '.data.repository.issue.parent.number // "" | tostring')
 ```
 
-`// ""` turns a JSON `null` into an empty string (same pattern as 4.4) so `[[ -z ... ]]` is reliable.
+`// ""` turns a JSON `null` into an empty string so `[[ -z ... ]]` is reliable.
 
 - **Matches `$parent_number`** → success. Continue to 4.6 (Archive).
 - **Empty or mismatched** → wait 2 seconds, retry the mutation from 4.5.2 once, then re-verify.
-- **Still wrong after retry** → report a fenced code block with the actual `$parent_node_id` / `$issue_node_id` / `$N` values **substituted inline** before display:
+- **Still wrong after retry** → report a fenced code block with the actual `$parent_node_id` / `$issue_node_id` / `$parent_number` / `$N` values **substituted inline** before display:
 
   ````
   Issue #<actual N> created but parent linkage to #<actual parent_number> failed. Retry manually:

--- a/plugins/athena-notes/skills/issue-create/SKILL.md
+++ b/plugins/athena-notes/skills/issue-create/SKILL.md
@@ -241,15 +241,15 @@ Branch on a successful response:
 
 Forgejo has no native sub-issue concept — skip this entire subsection silently on the Forgejo path. The flow continues to Stage 3 with `parent` empty in the draft frontmatter.
 
-**Always search.** Even when the candidate set is empty, prompt the user — never silently skip. Some issues legitimately have no parent, but that's the user's call.
+**Always prompt.** Even when the candidate set is empty, ask the user in 2.3.4 — never silently skip. Some issues legitimately have no parent, but that's the user's call.
 
 #### 2.3.1 Build the candidate set
 
-Two sources, used differently:
+Two sources, used differently. **In each loop, drop any value that fails `[[ "$n" =~ ^[0-9]+$ ]]` before it lands in the array** — the batched GraphQL query in 2.3.2 interpolates these numbers directly into the alias list, so a non-integer value here is a query-injection vector. Validate at the source, not at the union.
 
-1. **Seed `#N` references → `direct_parents[]`.** Scan the user's initial framing and Q&A answers for bare `#N` patterns (drop cross-repo `{owner}/{repo}#N` references — this skill only links within the target repo). When someone says "follow-up to #656" the natural reading is that *#656 is the parent* — surface these directly as parent options in 2.3.4 rather than treating them as siblings to infer a parent from.
+1. **Seed `#N` references → `direct_parents[]`.** Scan the user's initial framing and Q&A answers for bare `#N` patterns (drop cross-repo `{owner}/{repo}#N` references — this skill only links within the target repo). For each match, push the captured number onto `direct_parents[]` only if it passes the positive-integer regex; otherwise drop it. When someone says "follow-up to #656" the natural reading is that *#656 is the parent* — surface these directly as parent options in 2.3.4 rather than treating them as siblings to infer a parent from.
 
-2. **Label-cluster siblings → `siblings[]`.** Open issues in the target repo that share **all** selected labels (full intersection). Skipped if no labels were selected in 2.2 — full-intersection on zero labels matches every open issue, which is noise.
+2. **Label-cluster siblings → `siblings[]`.** Open issues in the target repo that share **all** selected labels (full intersection). Skipped if no labels were selected in 2.2 — full-intersection on zero labels matches every open issue, which is noise. The `gh issue list --json number` output is already integer-typed, but pipe each line through the same regex guard before pushing onto `siblings[]` so the validation invariant is maintained at every entry point to the candidate set.
 
    ```bash
    search_terms=""
@@ -267,8 +267,6 @@ Two sources, used differently:
      --jq '.[].number'
    ```
 
-**Validate** every value in both arrays as a positive integer (`[[ "$n" =~ ^[0-9]+$ ]]`) before they reach 2.3.2. The batched GraphQL query in 2.3.2 interpolates these numbers directly into the alias list; a non-integer value would be a query-injection vector. Drop anything that fails the regex.
-
 Build the de-duplicated query set: `candidates = direct_parents ∪ siblings`. Cap at 20. If `candidates` is empty → skip 2.3.2 and 2.3.3, jump to 2.3.4 (still prompt, with `(no candidates detected)`).
 
 #### 2.3.2 Query candidates
@@ -276,7 +274,7 @@ Build the de-duplicated query set: `candidates = direct_parents ∪ siblings`. C
 One batched GraphQL request, one alias per candidate. Fetch each candidate's own `state` + `title` (used to render direct parents as options) and its `parent { … }` (used to derive convergence among siblings). Without `-H "GraphQL-Features: sub_issues"` the `parent` field returns `Field 'parent' doesn't exist on type 'Issue'`.
 
 ```bash
-# 'i' prefix is stripped by --jq's sub("^i"; "") below — keep in sync if it ever changes.
+# 'i' prefix required — GraphQL alias names cannot start with a digit. Stripped in --jq via sub("^i"; "").
 aliases=""
 for n in "${candidates[@]}"; do
   aliases+="i${n}: issue(number: ${n}) { number title state parent { number title url state } }
@@ -314,13 +312,7 @@ Use `AskUserQuestion` single-select. Always include all of:
 
 - **Direct parents** (one option per `direct_parents[]` entry): `Link under #N — {title}` or `Link under #N — {title} (closed)` when `self.state == "CLOSED"`. Listed first — the user named these explicitly, so they should not have to retype them via `Specify`.
 - **Inferred parents** from 2.3.3 (up to 3): same option shape, ` (closed)` when the parent's `state == "CLOSED"`.
-- `Specify a different parent` — on selection, ask a follow-up turn: *"Parent issue number? (e.g. `42`, or `skip`)"*. Validate the answer parses as a positive integer; on invalid input or `skip`, treat as `No parent`. Then look up the typed number's title + state and confirm before persisting:
-
-  ```bash
-  parent_meta=$(gh api "repos/$owner/$repo/issues/$specified_n" --jq '{title, state}')
-  ```
-
-  Surface a confirmation prompt: *"Link under #{specified_n} — {title} ({state})?"*. On `no`, an empty `parent_meta` (404), or any error, treat as `No parent`. This keeps the closed-state visibility symmetric with the direct-parent and convergence paths.
+- `Specify a different parent` — on selection, ask a follow-up turn: *"Parent issue number? (e.g. `42`, or `skip`)"*. Validate the answer parses as a positive integer; on invalid input or `skip`, treat as `No parent`. Persist the typed number directly — Stage 4.5.3's verify step catches a non-existent or otherwise invalid parent on the post side. We deliberately don't pre-confirm or surface state at draft time; the user typed the number explicitly, and a closed-parent linkage is allowed.
 - `No parent` — default. The natural choice when no candidates surfaced or the user has none in mind.
 
 Capture the result as a single integer (parent issue number) or empty.
@@ -601,7 +593,7 @@ verified_type=$(gh api graphql -f query='
 
 - **Non-empty** (returns a name) → success. Continue to 4.5.
 - **Empty** → wait 2 seconds, retry the mutation from 4.3.2 once, then re-verify.
-- **Still empty after retry** → report: "Issue #{N} created but type not set. Retry manually: `gh api graphql -f query='mutation { updateIssueIssueType(input: {issueId: \"$issue_node_id\", issueTypeId: \"$type_id\"}) { issue { issueType { name } } } }'`." Continue to 4.5 anyway — the issue exists.
+- **Still empty after retry** → report: "Issue #{N} created but type not set. Retry manually: `gh api graphql -f query='mutation { updateIssueIssueType(input: {issueId: \"$issue_node_id\", issueTypeId: \"$type_id\"}) { issue { issueType { name } } } }'`." Continue to 4.5 (Link parent) anyway — the issue exists.
 
 ### 4.5 Link parent issue (GitHub only, when `parent` set in 2.3)
 
@@ -725,7 +717,8 @@ Then ask: "Start working on this now?" If yes, invoke the `issue-work` skill wit
 | Dedup check finds identical title | Surface + ask — never auto-merge |
 | GraphQL rate-limited | Surface the rate-reset time from the response header; don't loop |
 | `sub_issues` preview disabled on the account | Stage 2.3.2 surfaces the error; ask `[yes / stop]` to continue without parent linkage |
-| Parent number user typed (`Specify a different parent`) doesn't exist | Skip linkage with a one-line note; issue still posts |
+| Parent number user typed (`Specify a different parent`) is invalid (non-integer, `skip`, or empty) | Treat as `No parent` silently; `parent:` stays empty in the draft |
+| Confirmed parent number is valid at draft time but doesn't exist (or is inaccessible) at post time | Stage 4.5.1 reports `"Parent #N lookup failed — skipping linkage."` and continues to 4.6; the issue still posts |
 | Convergence picks a closed parent | Offer it with `(closed)` in the option label; user decides |
 | User picks a parent in 2.3 but post fails in 4.2 | Draft retains `parent:` in frontmatter; re-invoking `/issue-create` resumes with the choice intact |
 


### PR DESCRIPTION
## Summary

- New **Stage 2.3 (Parent linkage)** in `issue-create` builds a candidate set from seed `#N` references (direct parent suggestions) and label-cluster siblings (parent inference via `issue.parent`), batches one GraphQL request with one alias per candidate, surfaces convergence + direct parents via `AskUserQuestion`, and persists the user's choice as `parent:` on the draft frontmatter. Always prompts — even with no candidates — so the user remains the decider.
- New **Stage 4.5 (Link parent)** calls `addSubIssue(input: {issueId, subIssueId})` after creation when a parent was chosen, then verifies via `issue.parent` re-query (mirrors 4.3+4.4 mutation+verify+retry pattern). Forgejo skips both stages silently — no native sub-issue concept.
- Both new GraphQL calls send `-H "GraphQL-Features: sub_issues"` for the public-preview API. Existing 4.3 `updateIssueIssueType` is untouched (separate preview, no header needed).
- Renumbered Archive 4.5→4.6 and Report 4.6→4.7. Report adds a Parent: line. Edge Cases table picks up four new rows. The "Does NOT do" entry on auto-linking is rephrased to reflect that parent suggestions are surfaced but never linked without confirmation.
- No caching — per the ticket, parent relationships are per-issue, not per-repo, so a cache would just go stale.

## Test plan

This is a prompt-driven Claude Code skill — no automated test harness in this repo.

- [x] `scripts/lint-frontmatter.py` — clean across all 6 commits (14 agents, 18 skills validated)
- [x] All five plan acceptance criteria walked and confirmed present in the diff (correctness reviewer pass-by-pass cross-checks)
- [x] Stage numbering internally consistent — no orphan references to old 4.5/4.6 headings; cross-skill grep confirms no sibling skill references issue-create stage numbers
- [x] `GraphQL-Features: sub_issues` header in all three new locations (2.3.2 read, 4.5.2 write, 4.5.3 verify) and absent from 4.3 type-set (separate preview)
- [x] `parent:` frontmatter field added to draft template, referenced in 2.3.5 (write), 4.5 preamble (read), and 4.5 skip condition
- [ ] Manual smoke test (post-merge, optional) — invoke `/issue-create` against a real follow-up scenario and confirm parent linkage now happens before the user prompts for it

## Changelog

- [x] **Non-release PR** — added a bullet under `## [Unreleased]` in `CHANGELOG.md`.
- [ ] **Release PR (`vX.Y.Z`)** — bumped `plugins/athena-notes/.claude-plugin/plugin.json`, promoted `[Unreleased]` under `## [X.Y.Z] — YYYY-MM-DD`, added the `[X.Y.Z]: .../releases/tag/vX.Y.Z` footer, and retargeted `[Unreleased]` to `compare/vX.Y.Z...HEAD`.
  - [ ] **After merge:** `gh release create vX.Y.Z --target <merge-sha> --title "vX.Y.Z — <summary>"` — otherwise the footer link 404s.
- [ ] **Exempt** — only touched docs, `.github/`, `LICENSE`, or `CHANGELOG.md` itself.

---

Closes #47

### Self-review

5 passes of `/pr-self-review` (correctness / security / simplicity, parallel) before opening this PR. 31 findings accepted and fixed across 5 review-pass commits; 13 push-backs/skips on out-of-scope or repeat findings. **No outstanding critical or major findings.** Two minor diagnosability concerns deliberately deferred (label-DSL widening, auth-vs-404 collapse) — both confined to read-only paths with authoritative-data trust boundaries; rationale in the per-pass commit messages.

| Pass | Findings | Accepted | Pushed back / skipped |
|---|---|---|---|
| 1 | 11 (1 maj) | 8 | 1 PB, 2 skip |
| 2 | 8 (1 maj) | 6 | 2 skip |
| 3 | 8 (1 maj) | 7 | 1 skip |
| 4 | 15 (3 maj) | 6 | 8 skip/PB |
| 5 | 11 (1 maj) | 4 | 7 skip/PB |