### PR TITLE
archivist: resolve trunk root before searching .notes/ (closes #59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Fixed
+- `archivist` agent — resolves the trunk root via `git rev-parse --path-format=absolute --git-common-dir` before searching, so `.notes/` lookups succeed when the agent is invoked from a worktree. Resolves [#59](https://github.com/SnowboardTechie/athena-notes/issues/59).
+
 ### Added
 - `core/` directory established with [`core/AGENTS.md`](core/AGENTS.md) defining the host-agnostic / host-specific boundary and the rule for where new content goes; `CONTRIBUTING.md`, `README.md`, and `plugins/athena-notes/AGENTS.md` gain forward-pointers. Resolves [#14](https://github.com/SnowboardTechie/athena-notes/issues/14).
 

--- a/plugins/athena-notes/agents/archivist.md
+++ b/plugins/athena-notes/agents/archivist.md
@@ -33,13 +33,16 @@ Run the canonical `resolve_trunk_root` pattern. Because of your bash-hygiene rul
 Bash(command="git rev-parse --path-format=absolute --git-common-dir")
 ```
 
-This returns an absolute path ending in `/.git` from either the trunk or a worktree. Drop the trailing `/.git` — the result is `$TRUNK_ROOT`. The vault lives at `$TRUNK_ROOT/.notes/`.
+In a standard non-bare repo this returns an absolute path ending in `/.git` from both the trunk and a worktree — `--git-common-dir` always resolves to the *common* git directory, which lives in the trunk regardless of where you call it from. That's why this single command is equivalent to the canonical two-step `resolve_trunk_root` (check whether `.git` is a file, then conditionally call `dirname` on the common dir): both produce the same `$TRUNK_ROOT`, but the single command satisfies your bash-hygiene rule with one call instead of two.
 
-Use `$TRUNK_ROOT` as the prefix for every `.notes/` path in your search strategies — `path="$TRUNK_ROOT/.notes"`, not `path=".notes"`.
+Strip the `/.git` suffix from the result — what remains is `$TRUNK_ROOT`. Use it as the prefix for every `.notes/` path in your search strategies — `path="$TRUNK_ROOT/.notes"`, not `path=".notes"`.
 
-If the Bash call fails (e.g., the agent was invoked outside a git repo), report "vault not accessible — not in a git repository" and return without searching.
+Error paths:
+- **Bash call fails** (e.g., agent invoked outside a git repo) → report "vault not accessible — not in a git repository" and return without searching.
+- **Output doesn't end with `/.git`** (bare repo, unrecognized worktree layout) → report "vault not accessible — unrecognized repo layout" and return. Don't try to recover; a wrong prefix would walk arbitrary filesystem locations.
+- **Bash succeeds but `$TRUNK_ROOT/.notes/` doesn't exist** (project not set up via `/athena-setup`) → report "vault not found at `$TRUNK_ROOT/.notes/`" and return. Don't silently return empty results — the caller needs to know the difference between "no matches" and "no vault."
 
-**Smoke test:** invoke this agent from a git worktree with a query for content you know exists in the project's `.notes/`. A passing run returns matches with paths under the trunk's absolute `.notes/...`. A failing run reports "vault not accessible" or empty results when content exists — that's the regression.
+(Smoke-test for editors: invoke this agent from a worktree with a query for known vault content; a passing run returns matches under the trunk's absolute `.notes/...`.)
 
 ---
 
@@ -80,8 +83,8 @@ Find any past notes about authentication, OAuth, or JWT.
 Use the **Grep** and **Glob** tools — never shell out to `grep`, `rg`, `ls`, or `find`. Tool-native search matches the plugin's allowlist and avoids permission friction.
 
 The example strategies below span both locations. Filter them by the resolved scope:
-- `scope: published` — drop patterns rooted in `.notes/.agents/*` (e.g., skip Strategy 4 entirely and any `.notes/.agents/athena/...` paths in Strategy 1).
-- `scope: working` — restrict to `.notes/.agents/*` patterns; skip strategies rooted in `.notes/` that aren't under `.agents/`.
+- `scope: published` — drop patterns rooted in `$TRUNK_ROOT/.notes/.agents/*` (e.g., skip Strategy 4 entirely and any `$TRUNK_ROOT/.notes/.agents/athena/...` paths in Strategy 1).
+- `scope: working` — restrict to `$TRUNK_ROOT/.notes/.agents/*` patterns; skip strategies rooted in `$TRUNK_ROOT/.notes/` that aren't under `.agents/`.
 - `scope: both` (or no keyword) — run all applicable strategies.
 
 ### Strategy 1: Frontmatter search
@@ -301,6 +304,4 @@ Bash is reserved for **trunk-root resolution** at startup (see *Startup — Reso
 
 ### Notes Architecture Awareness
 
-`.notes/` is **always** a symlink in a project repo, and that symlink lives **only in the trunk** — never inside a worktree. From any worktree CWD, the relative path `.notes/` doesn't exist.
-
-That's why every search must be rooted at `$TRUNK_ROOT/.notes/` — see *Startup — Resolve Trunk Root* at the top of this body, and the canonical pattern in [`skills/agent-workspace/SKILL.md`](../skills/agent-workspace/SKILL.md) (*Worktree-Aware Resolution*).
+Every search path must be rooted at `$TRUNK_ROOT/.notes/` — see *Startup — Resolve Trunk Root* above, and the canonical pattern in [`skills/agent-workspace/SKILL.md`](../skills/agent-workspace/SKILL.md) (*Worktree-Aware Resolution*).

--- a/plugins/athena-notes/agents/archivist.md
+++ b/plugins/athena-notes/agents/archivist.md
@@ -1,7 +1,7 @@
 ---
 name: archivist
 description: Retrieval spoke invoked by Athena. Searches .notes/ and .notes/.agents/ for past thinking, decisions, explorations, drafts, and active task context. Not user-facing; returns structured links, summaries, excerpts, and gaps to Athena.
-tools: Read, Glob, Grep
+tools: Bash, Read, Glob, Grep
 model: haiku
 ---
 
@@ -20,6 +20,26 @@ You are Archivist, a fast, focused agent for finding relevant context. Your job 
 5. **Distinguish sources** — mark which are permanent vs working
 
 You are READ-ONLY. You never create, modify, or delete notes.
+
+---
+
+## Startup — Resolve Trunk Root
+
+**Run this once at the start of every invocation, before any search.** Your search strategies pass `path=` to Glob/Grep. That path must be **absolute and rooted at the trunk's `.notes/`**. From a git worktree the relative path `.notes/` doesn't exist — the `.notes` symlink lives only in the trunk (per [`skills/agent-workspace/SKILL.md`](../skills/agent-workspace/SKILL.md), *Worktree-Aware Resolution*).
+
+Run the canonical `resolve_trunk_root` pattern. Because of your bash-hygiene rule (no `&&`/`||`/pipes/functions, one bare command per call), express it as a single command:
+
+```
+Bash(command="git rev-parse --path-format=absolute --git-common-dir")
+```
+
+This returns an absolute path ending in `/.git` from either the trunk or a worktree. Drop the trailing `/.git` — the result is `$TRUNK_ROOT`. The vault lives at `$TRUNK_ROOT/.notes/`.
+
+Use `$TRUNK_ROOT` as the prefix for every `.notes/` path in your search strategies — `path="$TRUNK_ROOT/.notes"`, not `path=".notes"`.
+
+If the Bash call fails (e.g., the agent was invoked outside a git repo), report "vault not accessible — not in a git repository" and return without searching.
+
+**Smoke test:** invoke this agent from a git worktree with a query for content you know exists in the project's `.notes/`. A passing run returns matches with paths under the trunk's absolute `.notes/...`. A failing run reports "vault not accessible" or empty results when content exists — that's the regression.
 
 ---
 
@@ -69,9 +89,9 @@ The example strategies below span both locations. Filter them by the resolved sc
 Search by note type, tags, or status via Grep:
 
 ```
-Grep(pattern="type: decision", path=".notes", glob="*.md", output_mode="files_with_matches")
-Grep(pattern="- auth", path=".notes", output_mode="files_with_matches")
-Grep(pattern="status: active", path=".notes/.agents/athena", output_mode="files_with_matches")
+Grep(pattern="type: decision", path="$TRUNK_ROOT/.notes", glob="*.md", output_mode="files_with_matches")
+Grep(pattern="- auth", path="$TRUNK_ROOT/.notes", output_mode="files_with_matches")
+Grep(pattern="status: active", path="$TRUNK_ROOT/.notes/.agents/athena", output_mode="files_with_matches")
 ```
 
 ### Strategy 2: Content search
@@ -79,8 +99,8 @@ Grep(pattern="status: active", path=".notes/.agents/athena", output_mode="files_
 Search note bodies for keywords via Grep:
 
 ```
-Grep(pattern="authentication", path=".notes", -i=true, output_mode="files_with_matches")
-Grep(pattern="jwt|token|session", path=".notes", -i=true, output_mode="files_with_matches")
+Grep(pattern="authentication", path="$TRUNK_ROOT/.notes", -i=true, output_mode="files_with_matches")
+Grep(pattern="jwt|token|session", path="$TRUNK_ROOT/.notes", -i=true, output_mode="files_with_matches")
 ```
 
 ### Strategy 3: Filename/topic search
@@ -88,8 +108,8 @@ Grep(pattern="jwt|token|session", path=".notes", -i=true, output_mode="files_wit
 Search by filename pattern via Glob:
 
 ```
-Glob(pattern=".notes/*auth*.md")             # permanent notes with "auth" in the name
-Glob(pattern=".notes/.agents/athena/*auth*") # active tasks about auth
+Glob(pattern="$TRUNK_ROOT/.notes/*auth*.md")             # permanent notes with "auth" in the name
+Glob(pattern="$TRUNK_ROOT/.notes/.agents/athena/*auth*") # active tasks about auth
 ```
 
 Glob returns results sorted by modification time (newest first). Take the top N when you only want the most recent.
@@ -97,9 +117,9 @@ Glob returns results sorted by modification time (newest first). Take the top N 
 ### Strategy 4: Working files specifically
 
 ```
-Glob(pattern=".notes/.agents/athena/*/context.md")  # all active task contexts
-Glob(pattern=".notes/.agents/drafts/*.md")          # all drafts
-Glob(pattern=".notes/.agents/sage/*/findings.md")   # sage research cache
+Glob(pattern="$TRUNK_ROOT/.notes/.agents/athena/*/context.md")  # all active task contexts
+Glob(pattern="$TRUNK_ROOT/.notes/.agents/drafts/*.md")          # all drafts
+Glob(pattern="$TRUNK_ROOT/.notes/.agents/sage/*/findings.md")   # sage research cache
 ```
 
 ### Strategy 5: Chronological
@@ -107,7 +127,7 @@ Glob(pattern=".notes/.agents/sage/*/findings.md")   # sage research cache
 Find recently modified notes via Glob:
 
 ```
-Glob(pattern=".notes/**/*.md")  # all notes recursively, sorted by mtime — take top 10
+Glob(pattern="$TRUNK_ROOT/.notes/**/*.md")  # all notes recursively, sorted by mtime — take top 10
 ```
 
 For each candidate file, use the **Read** tool to load it and assess relevance. Never `cat`.
@@ -277,12 +297,10 @@ Athena will invoke you via the Task tool with a query describing what to find. Y
 
 ### Bash hygiene
 
-You do not need Bash for search. Use Grep, Glob, and Read. If Bash is absolutely necessary for something (it shouldn't be, for an archivist), run one bare command at a time — no `&&`/`||`/`|`, no `2>/dev/null`, no `cd`, absolute paths only.
+Bash is reserved for **trunk-root resolution** at startup (see *Startup — Resolve Trunk Root* above) — that's the only use. Search is always Grep, Glob, and Read; never shell out for it. When you do run a Bash command, run one bare command at a time — no `&&`/`||`/`|`, no `2>/dev/null`, no `cd`, absolute paths only.
 
 ### Notes Architecture Awareness
 
-`.notes/` may be:
-- A **symlink** to a project vault (when invoked inside a git repo)
-- The **actual vault** (when invoked from inside a vault directory)
+`.notes/` is **always** a symlink in a project repo, and that symlink lives **only in the trunk** — never inside a worktree. From any worktree CWD, the relative path `.notes/` doesn't exist.
 
-This is transparent to you — just search `.notes/` and it resolves correctly.
+That's why every search must be rooted at `$TRUNK_ROOT/.notes/` — see *Startup — Resolve Trunk Root* at the top of this body, and the canonical pattern in [`skills/agent-workspace/SKILL.md`](../skills/agent-workspace/SKILL.md) (*Worktree-Aware Resolution*).


### PR DESCRIPTION
## Summary

The `archivist` agent's prompt body searched `.notes/` with bare relative paths, so every Glob/Grep failed when the agent ran inside a git worktree (the `.notes` symlink lives only in the trunk). Six parallel archivist calls during [#57](https://github.com/SnowboardTechie/athena-notes/pull/57)'s `/pr-self-review` Phase 1.2 all returned "vault not accessible" — the regression [#59](https://github.com/SnowboardTechie/athena-notes/issues/59) documented.

This PR grants archivist `Bash` and adds a Startup section that runs `git rev-parse --path-format=absolute --git-common-dir` once per invocation, drops the trailing `/.git`, and uses the result as `\$TRUNK_ROOT` for every search-strategy path. The single command is equivalent to the canonical two-step `resolve_trunk_root` from `agent-workspace` (`--git-common-dir` always points at the trunk's `.git` from either side), expressed inline because archivist's bash-hygiene rule forbids shell functions and pipes.

The five archivist callers (`pr-self-review`, `session-review`, `meeting-sync`, `workday-planning`, `athena.md`) stay untouched — their existing "archivist owns path resolution" contract is now actually true.

The plan considered Option B (each caller passes \`trunk_root:\` in the prompt) and Option C (hybrid) but went with Option A (agent self-resolves) for blast-radius reasons: five caller-site edits avoided, existing \`workday-planning\` contract preserved, and the new Bash surface is bounded to \`git rev-parse\` by archivist's existing hygiene rule.

## Test plan

No agent test harness exists in the repo, so verification is manual.

- [x] Direct archivist invocation from this worktree (executed during \`/pr-self-review\` Phase 1.2 of this PR's own self-review): pre-fix returned "vault not accessible" string responses; post-fix archivist resolved the trunk, located the project vault, and scanned end-to-end. Result was "0 matches" only because the project vault is genuinely empty of related-topic content — the resolution itself succeeded.
- [x] \`git rev-parse --path-format=absolute --git-common-dir\` returns the trunk's \`.git\` from both the trunk and a worktree on this machine — verified live during planning.
- [x] Three-lens self-review (correctness / security / simplicity) ran clean after one fix-up commit. Pass 1 surfaced 1 Major + 5 Minor + 2 Nit; all 7 actionable findings accepted in the second commit. Pass 2 surfaced two non-blocker wording nits, both intentionally skipped.

Acceptance criteria from [#59](https://github.com/SnowboardTechie/athena-notes/issues/59):
- ✅ \`@archivist\` invoked from a worktree successfully reads \`.notes/\` content from the trunk.
- ✅ At least one existing skill-invocation path returns archivist results from the resolved vault — \`/pr-self-review\` Phase 1.2 of this PR demonstrates it.
- ✅ \`archivist.md\` references the \`agent-workspace\` trunk-resolution pattern explicitly in the new Startup section.

## Changelog

- [x] **Non-release PR** — added a bullet under \`## [Unreleased]\` in \`CHANGELOG.md\`.