### PR TITLE
archivist: tool-native vault check; {TRUNK_ROOT} placeholder syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 
 ### Fixed
 - `archivist` agent — resolves the trunk root via `git rev-parse --path-format=absolute --git-common-dir` before searching, so `.notes/` lookups succeed when the agent is invoked from a worktree. Resolves [#59](https://github.com/SnowboardTechie/athena-notes/issues/59).
+- `archivist` agent — vault-existence error path now specifies a `Glob` check rather than leaving the verification mechanism implicit; placeholder syntax switched from `$TRUNK_ROOT` to `{TRUNK_ROOT}` to match `agent-workspace`. Follow-up to [#59](https://github.com/SnowboardTechie/athena-notes/issues/59).
 
 ### Added
 - `core/` directory established with [`core/AGENTS.md`](core/AGENTS.md) defining the host-agnostic / host-specific boundary and the rule for where new content goes; `CONTRIBUTING.md`, `README.md`, and `plugins/athena-notes/AGENTS.md` gain forward-pointers. Resolves [#14](https://github.com/SnowboardTechie/athena-notes/issues/14).

--- a/plugins/athena-notes/agents/archivist.md
+++ b/plugins/athena-notes/agents/archivist.md
@@ -33,14 +33,14 @@ Run the canonical `resolve_trunk_root` pattern. Because of your bash-hygiene rul
 Bash(command="git rev-parse --path-format=absolute --git-common-dir")
 ```
 
-In a standard non-bare repo this returns an absolute path ending in `/.git` from both the trunk and a worktree — `--git-common-dir` always resolves to the *common* git directory, which lives in the trunk regardless of where you call it from. That's why this single command is equivalent to the canonical two-step `resolve_trunk_root` (check whether `.git` is a file, then conditionally call `dirname` on the common dir): both produce the same `$TRUNK_ROOT`, but the single command satisfies your bash-hygiene rule with one call instead of two.
+In a standard non-bare repo this returns an absolute path ending in `/.git` from both the trunk and a worktree — `--git-common-dir` always resolves to the *common* git directory, which lives in the trunk regardless of where you call it from. That's why this single command is equivalent to the canonical two-step `resolve_trunk_root` (check whether `.git` is a file, then conditionally call `dirname` on the common dir): both produce the same `{TRUNK_ROOT}`, but the single command satisfies your bash-hygiene rule with one call instead of two.
 
-Strip the `/.git` suffix from the result — what remains is `$TRUNK_ROOT`. Use it as the prefix for every `.notes/` path in your search strategies — `path="$TRUNK_ROOT/.notes"`, not `path=".notes"`.
+Strip the `/.git` suffix from the result — what remains is `{TRUNK_ROOT}`. Use it as the prefix for every `.notes/` path in your search strategies — `path="{TRUNK_ROOT}/.notes"`, not `path=".notes"`.
 
 Error paths:
 - **Bash call fails** (e.g., agent invoked outside a git repo) → report "vault not accessible — not in a git repository" and return without searching.
 - **Output doesn't end with `/.git`** (bare repo, unrecognized worktree layout) → report "vault not accessible — unrecognized repo layout" and return. Don't try to recover; a wrong prefix would walk arbitrary filesystem locations.
-- **Bash succeeds but `$TRUNK_ROOT/.notes/` doesn't exist** (project not set up via `/athena-setup`) → report "vault not found at `$TRUNK_ROOT/.notes/`" and return. Don't silently return empty results — the caller needs to know the difference between "no matches" and "no vault."
+- **`{TRUNK_ROOT}/.notes/` doesn't exist** (project not set up via `/athena-setup`) — check with `Glob(pattern="{TRUNK_ROOT}/.notes")`. No result → report "vault not found at `{TRUNK_ROOT}/.notes/`" and return. Don't silently return empty results — the caller needs to know the difference between "no matches" and "no vault."
 
 (Smoke-test for editors: invoke this agent from a worktree with a query for known vault content; a passing run returns matches under the trunk's absolute `.notes/...`.)
 
@@ -83,8 +83,8 @@ Find any past notes about authentication, OAuth, or JWT.
 Use the **Grep** and **Glob** tools — never shell out to `grep`, `rg`, `ls`, or `find`. Tool-native search matches the plugin's allowlist and avoids permission friction.
 
 The example strategies below span both locations. Filter them by the resolved scope:
-- `scope: published` — drop patterns rooted in `$TRUNK_ROOT/.notes/.agents/*` (e.g., skip Strategy 4 entirely and any `$TRUNK_ROOT/.notes/.agents/athena/...` paths in Strategy 1).
-- `scope: working` — restrict to `$TRUNK_ROOT/.notes/.agents/*` patterns; skip strategies rooted in `$TRUNK_ROOT/.notes/` that aren't under `.agents/`.
+- `scope: published` — drop patterns rooted in `{TRUNK_ROOT}/.notes/.agents/*` (e.g., skip Strategy 4 entirely and any `{TRUNK_ROOT}/.notes/.agents/athena/...` paths in Strategy 1).
+- `scope: working` — restrict to `{TRUNK_ROOT}/.notes/.agents/*` patterns; skip strategies rooted in `{TRUNK_ROOT}/.notes/` that aren't under `.agents/`.
 - `scope: both` (or no keyword) — run all applicable strategies.
 
 ### Strategy 1: Frontmatter search
@@ -92,9 +92,9 @@ The example strategies below span both locations. Filter them by the resolved sc
 Search by note type, tags, or status via Grep:
 
 ```
-Grep(pattern="type: decision", path="$TRUNK_ROOT/.notes", glob="*.md", output_mode="files_with_matches")
-Grep(pattern="- auth", path="$TRUNK_ROOT/.notes", output_mode="files_with_matches")
-Grep(pattern="status: active", path="$TRUNK_ROOT/.notes/.agents/athena", output_mode="files_with_matches")
+Grep(pattern="type: decision", path="{TRUNK_ROOT}/.notes", glob="*.md", output_mode="files_with_matches")
+Grep(pattern="- auth", path="{TRUNK_ROOT}/.notes", output_mode="files_with_matches")
+Grep(pattern="status: active", path="{TRUNK_ROOT}/.notes/.agents/athena", output_mode="files_with_matches")
 ```
 
 ### Strategy 2: Content search
@@ -102,8 +102,8 @@ Grep(pattern="status: active", path="$TRUNK_ROOT/.notes/.agents/athena", output_
 Search note bodies for keywords via Grep:
 
 ```
-Grep(pattern="authentication", path="$TRUNK_ROOT/.notes", -i=true, output_mode="files_with_matches")
-Grep(pattern="jwt|token|session", path="$TRUNK_ROOT/.notes", -i=true, output_mode="files_with_matches")
+Grep(pattern="authentication", path="{TRUNK_ROOT}/.notes", -i=true, output_mode="files_with_matches")
+Grep(pattern="jwt|token|session", path="{TRUNK_ROOT}/.notes", -i=true, output_mode="files_with_matches")
 ```
 
 ### Strategy 3: Filename/topic search
@@ -111,8 +111,8 @@ Grep(pattern="jwt|token|session", path="$TRUNK_ROOT/.notes", -i=true, output_mod
 Search by filename pattern via Glob:
 
 ```
-Glob(pattern="$TRUNK_ROOT/.notes/*auth*.md")             # permanent notes with "auth" in the name
-Glob(pattern="$TRUNK_ROOT/.notes/.agents/athena/*auth*") # active tasks about auth
+Glob(pattern="{TRUNK_ROOT}/.notes/*auth*.md")             # permanent notes with "auth" in the name
+Glob(pattern="{TRUNK_ROOT}/.notes/.agents/athena/*auth*") # active tasks about auth
 ```
 
 Glob returns results sorted by modification time (newest first). Take the top N when you only want the most recent.
@@ -120,9 +120,9 @@ Glob returns results sorted by modification time (newest first). Take the top N 
 ### Strategy 4: Working files specifically
 
 ```
-Glob(pattern="$TRUNK_ROOT/.notes/.agents/athena/*/context.md")  # all active task contexts
-Glob(pattern="$TRUNK_ROOT/.notes/.agents/drafts/*.md")          # all drafts
-Glob(pattern="$TRUNK_ROOT/.notes/.agents/sage/*/findings.md")   # sage research cache
+Glob(pattern="{TRUNK_ROOT}/.notes/.agents/athena/*/context.md")  # all active task contexts
+Glob(pattern="{TRUNK_ROOT}/.notes/.agents/drafts/*.md")          # all drafts
+Glob(pattern="{TRUNK_ROOT}/.notes/.agents/sage/*/findings.md")   # sage research cache
 ```
 
 ### Strategy 5: Chronological
@@ -130,7 +130,7 @@ Glob(pattern="$TRUNK_ROOT/.notes/.agents/sage/*/findings.md")   # sage research 
 Find recently modified notes via Glob:
 
 ```
-Glob(pattern="$TRUNK_ROOT/.notes/**/*.md")  # all notes recursively, sorted by mtime — take top 10
+Glob(pattern="{TRUNK_ROOT}/.notes/**/*.md")  # all notes recursively, sorted by mtime — take top 10
 ```
 
 For each candidate file, use the **Read** tool to load it and assess relevance. Never `cat`.
@@ -304,4 +304,4 @@ Bash is reserved for **trunk-root resolution** at startup (see *Startup — Reso
 
 ### Notes Architecture Awareness
 
-Every search path must be rooted at `$TRUNK_ROOT/.notes/` — see *Startup — Resolve Trunk Root* above, and the canonical pattern in [`skills/agent-workspace/SKILL.md`](../skills/agent-workspace/SKILL.md) (*Worktree-Aware Resolution*).
+Every search path must be rooted at `{TRUNK_ROOT}/.notes/` — see *Startup — Resolve Trunk Root* above, and the canonical pattern in [`skills/agent-workspace/SKILL.md`](../skills/agent-workspace/SKILL.md) (*Worktree-Aware Resolution*).


### PR DESCRIPTION
## Summary

Two follow-up edits from `/code-review` on [#68](https://github.com/SnowboardTechie/athena-notes/pull/68) — the PR that landed the original [#59](https://github.com/SnowboardTechie/athena-notes/issues/59) fix.

- **Error path 3** — vault-not-found check now specifies `Glob(pattern="{TRUNK_ROOT}/.notes")` rather than leaving the verification mechanism implicit. Bash is reserved for trunk-resolution per the agent's hygiene rule, so the existence check has to be tool-native; without explicit guidance a haiku-class model could skip the check or reach for Bash again.
- **Placeholder syntax** — switched `$TRUNK_ROOT` → `{TRUNK_ROOT}` across the Startup section and all five search-strategy code blocks, matching the convention in [`plugins/athena-notes/skills/agent-workspace/SKILL.md`](plugins/athena-notes/skills/agent-workspace/SKILL.md). Both forms work for LLM substitution; mixed conventions inside one plugin invite future drift.

No behavior change beyond what archivist's prompt instructs the LLM to do — instruction-text tightenings only.

## Test plan

- [x] Reviewed diff line by line; both edits match the suggestions in the [#68 review thread](https://github.com/SnowboardTechie/athena-notes/pull/68).
- [x] `grep -n '\$TRUNK_ROOT'` against `plugins/athena-notes/agents/archivist.md` returns zero matches; `{TRUNK_ROOT}` appears 17 times.

## Changelog

- [x] **Non-release PR** — added a bullet under `## [Unreleased]` in `CHANGELOG.md`.