### PR TITLE
AGENTS.md: prefer sibling skill over extending an existing spoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 - `core/` directory established with [`core/AGENTS.md`](core/AGENTS.md) defining the host-agnostic / host-specific boundary and the rule for where new content goes; `CONTRIBUTING.md`, `README.md`, and `plugins/athena-notes/AGENTS.md` gain forward-pointers. Resolves [#14](https://github.com/SnowboardTechie/athena-notes/issues/14).
 
 ### Changed
+- `AGENTS.md` — adds rule under "When to add a new spoke" preferring a sibling skill over extending an existing spoke when an adjacent reasoning-shape match would otherwise warrant spoke shape.
 - `issue-create` skill — searches for a candidate parent issue before posting and links the new issue under it when the user confirms; Forgejo path skips silently. Resolves [#47](https://github.com/SnowboardTechie/athena-notes/issues/47).
 - `workday-planning` skill — Phase 8 now opens with a persistence receipt: `✅ Wrote: …` on a fresh write, `⏭️ Kept existing: …` when the user declines to overwrite. Resolves [#30](https://github.com/SnowboardTechie/athena-notes/issues/30).
 - `session-review` skill — adds a collaboration lens that routes cross-project user-preference signal (how the user thinks, project motivation, external-system pointers) to the harness memory system instead of the vault. Resolves [#13](https://github.com/SnowboardTechie/athena-notes/issues/13).

--- a/plugins/athena-notes/AGENTS.md
+++ b/plugins/athena-notes/AGENTS.md
@@ -54,6 +54,8 @@ A new spoke is warranted only when at least one applies:
 
 If none apply, the work stays in the invoking skill. Interactive multi-turn flows (user Q&A loops, triage) are the wrong shape for spokes — spokes return a single artifact, not a conversation. MCPs and skills cover architectures that look agent-shaped but aren't: MCP for tool surfaces exposed to many agents; skill for user-facing orchestration.
 
+When an existing spoke already does adjacent reasoning, prefer a sibling skill over extending the spoke — even if the criteria above would otherwise warrant spoke shape. Spokes derive value from focus; spreading forge's daily-goal sequencing into life-spanning option ranking dilutes its current value. Surfaced while drafting [#73](https://github.com/SnowboardTechie/athena-notes/issues/73).
+
 ### Parallel agents write to distinct output paths
 
 When spawning parallel Task or Explore agents, each agent needs its own output destination — never a shared file that multiple agents append to. Concurrent appends interleave silently and corrupt the output; file locking isn't reliable across agent boundaries. Two safe shapes:


### PR DESCRIPTION
## Summary

Adds a rule to `plugins/athena-notes/AGENTS.md` (under "When to add a new spoke vs. keep work in a skill"): when an existing spoke already does adjacent reasoning, prefer a sibling skill over extending the spoke — even if the criteria above would otherwise warrant spoke shape. Spokes derive value from focus.

Surfaced while drafting #73 (the `/whats-next` skill), where forge's priority/dependency/energy reasoning shape overlapped the new skill's synthesis but expanding forge's scope would have hurt its current daily-goal-sequencing job.

## Test plan
- [x] AGENTS.md addition reads cleanly in context (one paragraph, lives next to the existing "When to add a new spoke" criteria)
- [x] CHANGELOG `[Unreleased] → Changed` bullet describes the observable change
- [x] Versionable-paths CI rule satisfied (`plugins/athena-notes/AGENTS.md` change has CHANGELOG bullet)

## Changelog

- [x] **Non-release PR** — added a bullet under `## [Unreleased]` in `CHANGELOG.md`.