### PR TITLE
issue-work: Phase 1.6 worktree branches off origin/$DEFAULT_BRANCH (closes #61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 ### Fixed
 - `archivist` agent — resolves the trunk root via `git rev-parse --path-format=absolute --git-common-dir` before searching, so `.notes/` lookups succeed when the agent is invoked from a worktree. Resolves [#59](https://github.com/SnowboardTechie/athena-notes/issues/59).
 - `archivist` agent — vault-existence error path now specifies a `Glob` check rather than leaving the verification mechanism implicit; placeholder syntax switched from `$TRUNK_ROOT` to `{TRUNK_ROOT}` to match `agent-workspace`. Follow-up to [#59](https://github.com/SnowboardTechie/athena-notes/issues/59).
+- `issue-work` skill — Phase 1.6 worktree creation now branches off `origin/{DEFAULT_BRANCH}` regardless of the session's current HEAD, via a `git worktree add` against `{TRUNK_ROOT}` followed by `EnterWorktree(path: ...)`. The prior instructions called `EnterWorktree` with a non-existent `base_branch` parameter and silently branched off whatever the session was checked out on. Resolves [#61](https://github.com/SnowboardTechie/athena-notes/issues/61).
 
 ### Added
 - `core/` directory established with [`core/AGENTS.md`](core/AGENTS.md) defining the host-agnostic / host-specific boundary and the rule for where new content goes; `CONTRIBUTING.md`, `README.md`, and `plugins/athena-notes/AGENTS.md` gain forward-pointers. Resolves [#14](https://github.com/SnowboardTechie/athena-notes/issues/14).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 ### Fixed
 - `archivist` agent — resolves the trunk root via `git rev-parse --path-format=absolute --git-common-dir` before searching, so `.notes/` lookups succeed when the agent is invoked from a worktree. Resolves [#59](https://github.com/SnowboardTechie/athena-notes/issues/59).
 - `archivist` agent — vault-existence error path now specifies a `Glob` check rather than leaving the verification mechanism implicit; placeholder syntax switched from `$TRUNK_ROOT` to `{TRUNK_ROOT}` to match `agent-workspace`. Follow-up to [#59](https://github.com/SnowboardTechie/athena-notes/issues/59).
-- `issue-work` skill — Phase 1.6 worktree creation now branches off `origin/{DEFAULT_BRANCH}` regardless of the session's current HEAD, via a `git worktree add` against `{TRUNK_ROOT}` followed by `EnterWorktree(path: ...)`. The prior instructions called `EnterWorktree` with a non-existent `base_branch` parameter and silently branched off whatever the session was checked out on. Resolves [#61](https://github.com/SnowboardTechie/athena-notes/issues/61).
+- `issue-work` skill — Phase 1.6 worktree creation now branches off `origin/$DEFAULT_BRANCH` regardless of the session's current HEAD, via a `git worktree add` against `{TRUNK_ROOT}` followed by `EnterWorktree(path: ...)`. Resolves [#61](https://github.com/SnowboardTechie/athena-notes/issues/61).
 
 ### Added
 - `core/` directory established with [`core/AGENTS.md`](core/AGENTS.md) defining the host-agnostic / host-specific boundary and the rule for where new content goes; `CONTRIBUTING.md`, `README.md`, and `plugins/athena-notes/AGENTS.md` gain forward-pointers. Resolves [#14](https://github.com/SnowboardTechie/athena-notes/issues/14).

--- a/plugins/athena-notes/skills/issue-work/SKILL.md
+++ b/plugins/athena-notes/skills/issue-work/SKILL.md
@@ -128,7 +128,7 @@ If either auth check fails, stop and surface the error to the user — do not pr
 
 `EnterWorktree` only accepts `name` or `path` — there is no `base_branch` parameter, and `name`-form always branches off the session's current HEAD. From inside another worktree (the common case), that's the wrong base. Create the worktree with `git worktree add` against the trunk first, then enter it by path.
 
-Two-step pattern:
+Three-step pattern:
 
 1. **Compute the worktree slug and path.** `kebab-slug` = ticket title, lowercased, non-alphanumerics → `-`, collapsed, trimmed. The full worktree directory name is `{repo}.{N}-{kebab-slug}` (cap at 60 chars). The branch name is `issue-{N}-{kebab-slug}` — or match the repo's branch convention if recent branches in `git -C "{TRUNK_ROOT}" for-each-ref --format='%(refname:short)' --count=20 refs/heads/` suggest a different prefix (e.g., `bryan/issue-…`).
 

--- a/plugins/athena-notes/skills/issue-work/SKILL.md
+++ b/plugins/athena-notes/skills/issue-work/SKILL.md
@@ -114,24 +114,37 @@ if [[ "$forge" == "forgejo" && -z "${FORGEJO_TOKEN:-${GITEA_TOKEN:-}}" ]]; then
 fi
 
 # Fetch the actual default branch
-git -C "$TRUNK" fetch origin "$DEFAULT_BRANCH"
+git -C "{TRUNK_ROOT}" fetch origin "$DEFAULT_BRANCH"
 
 # Working tree clean? (modified or staged — ignore untracked)
-git -C "$TRUNK" status --porcelain | grep -E '^[ MADRC]'
+git -C "{TRUNK_ROOT}" status --porcelain | grep -E '^[ MADRC]'
 ```
 
 If either auth check fails, stop and surface the error to the user — do not proceed to worktree creation. If the trunk is dirty (modified/staged, not just untracked), stop and offer: stash / commit / abort. Do not silently stash.
 
 ### 1.6 Create worktree
 
-Use the `EnterWorktree` tool with:
+`EnterWorktree` only accepts `name` or `path` — there is no `base_branch` parameter, and `name`-form always branches off the session's current HEAD. From inside another worktree (the common case), that's the wrong base. Create the worktree with `git worktree add` against the trunk first, then enter it by path.
 
-- **Name**: `{repo}.{N}-{kebab-slug}` (max 60 chars)
-  - `kebab-slug` = ticket title, lowercased, non-alphanumerics → `-`, collapsed, trimmed
-- **Base branch**: the default branch from 1.5
-- **Branch name**: `issue-{N}-{kebab-slug}` (or match repo convention if apparent from recent branches)
+Two-step pattern:
 
-After worktree creation, `cd` to the worktree.
+1. **Compute the worktree slug and path.** `kebab-slug` = ticket title, lowercased, non-alphanumerics → `-`, collapsed, trimmed. The full worktree directory name is `{repo}.{N}-{kebab-slug}` (cap at 60 chars). The branch name is `issue-{N}-{kebab-slug}` — or match the repo's branch convention if recent branches in `git -C "{TRUNK_ROOT}" log --format='%D' -20` suggest a different prefix (e.g., `bryan/issue-…`).
+
+2. **Create the branch + worktree against the trunk.** `{TRUNK_ROOT}` is the local-clone path resolved in Phase 1.4. Pin the base to the remote ref so a stale local default doesn't become the parent commit:
+
+   ```
+   Bash(command="git -C {TRUNK_ROOT} worktree add -b issue-{N}-{kebab-slug} {TRUNK_ROOT}/.claude/worktrees/{repo}.{N}-{kebab-slug} origin/{DEFAULT_BRANCH}")
+   ```
+
+   Running against `{TRUNK_ROOT}` matters: if the session's cwd is another worktree, `git worktree add` invoked there would still resolve the same git common dir, but routing the call through the trunk path makes the intent explicit and keeps the new worktree under the trunk's `.claude/worktrees/` regardless of where the session was started.
+
+3. **Enter the new worktree by path** — `path`-form, not `name`-form. `name`-form would create a *second* worktree branched off the session's HEAD instead of entering the one just created:
+
+   ```
+   EnterWorktree(path="{TRUNK_ROOT}/.claude/worktrees/{repo}.{N}-{kebab-slug}")
+   ```
+
+**Resume case** (worktree directory already exists at the target path — e.g., `Phase 0 — Resume Check` flagged this ticket as resumed): skip step 2 entirely and call `EnterWorktree(path: ...)` directly. Do not run `git worktree add` against an existing path; it will error and the desired branch is already in place.
 
 ### 1.7 Write initial progress.md
 
@@ -359,7 +372,7 @@ Present the review outcome inline in this order:
 
 | Case | Behavior |
 |---|---|
-| Worktree already exists for this ticket | Skip creation; `EnterWorktree` into it; resume from `progress.md` status |
+| Worktree already exists for this ticket | Skip the `git worktree add` step in Phase 1.6; call `EnterWorktree(path: ...)` directly; resume from `progress.md` status |
 | Trunk dirty (modified/staged) | Stop. List files. Offer stash / commit / abort |
 | Ticket is a PR (review work, not new work) | Skip worktree creation; `gh pr checkout {N}` in trunk or fetch branch; swap Phase 3 for "review against plan"; Phase 4 reviewers still run |
 | Tests fail 3× | Stop; surface last failure output; ask user |

--- a/plugins/athena-notes/skills/issue-work/SKILL.md
+++ b/plugins/athena-notes/skills/issue-work/SKILL.md
@@ -90,6 +90,8 @@ Glob(pattern="$HOME/code/*/*/.git")
 
 If no local clone: ask before running `gh repo clone {owner}/{repo} ~/code/{repo}`.
 
+Bind the resolved clone path as `{TRUNK_ROOT}` — the placeholder Phase 1.5 and Phase 1.6 reference. If the resolved path is itself a worktree, resolve to the trunk via `git -C {path} rev-parse --path-format=absolute --git-common-dir` and strip the trailing `/.git` (same pattern the `archivist` agent uses; see [`agent-workspace/SKILL.md`](../agent-workspace/SKILL.md) → *Worktree-Aware Resolution*).
+
 ### 1.5 Pre-flight checks
 
 Run all of these against the trunk (not a worktree).
@@ -128,17 +130,15 @@ If either auth check fails, stop and surface the error to the user — do not pr
 
 Two-step pattern:
 
-1. **Compute the worktree slug and path.** `kebab-slug` = ticket title, lowercased, non-alphanumerics → `-`, collapsed, trimmed. The full worktree directory name is `{repo}.{N}-{kebab-slug}` (cap at 60 chars). The branch name is `issue-{N}-{kebab-slug}` — or match the repo's branch convention if recent branches in `git -C "{TRUNK_ROOT}" log --format='%D' -20` suggest a different prefix (e.g., `bryan/issue-…`).
+1. **Compute the worktree slug and path.** `kebab-slug` = ticket title, lowercased, non-alphanumerics → `-`, collapsed, trimmed. The full worktree directory name is `{repo}.{N}-{kebab-slug}` (cap at 60 chars). The branch name is `issue-{N}-{kebab-slug}` — or match the repo's branch convention if recent branches in `git -C "{TRUNK_ROOT}" for-each-ref --format='%(refname:short)' --count=20 refs/heads/` suggest a different prefix (e.g., `bryan/issue-…`).
 
-2. **Create the branch + worktree against the trunk.** `{TRUNK_ROOT}` is the local-clone path resolved in Phase 1.4. Pin the base to the remote ref so a stale local default doesn't become the parent commit:
+2. **Create the branch + worktree against the trunk.** Pin the base to the remote ref so a stale local default doesn't become the parent commit:
 
    ```
-   Bash(command="git -C {TRUNK_ROOT} worktree add -b issue-{N}-{kebab-slug} {TRUNK_ROOT}/.claude/worktrees/{repo}.{N}-{kebab-slug} origin/{DEFAULT_BRANCH}")
+   Bash(command="git -C \"{TRUNK_ROOT}\" worktree add -b issue-{N}-{kebab-slug} \"{TRUNK_ROOT}/.claude/worktrees/{repo}.{N}-{kebab-slug}\" \"origin/$DEFAULT_BRANCH\"")
    ```
 
-   Running against `{TRUNK_ROOT}` matters: if the session's cwd is another worktree, `git worktree add` invoked there would still resolve the same git common dir, but routing the call through the trunk path makes the intent explicit and keeps the new worktree under the trunk's `.claude/worktrees/` regardless of where the session was started.
-
-3. **Enter the new worktree by path** — `path`-form, not `name`-form. `name`-form would create a *second* worktree branched off the session's HEAD instead of entering the one just created:
+3. **Enter the new worktree by path** (path-form, not name-form):
 
    ```
    EnterWorktree(path="{TRUNK_ROOT}/.claude/worktrees/{repo}.{N}-{kebab-slug}")

--- a/plugins/athena-notes/skills/issue-work/references/repo-resolution.md
+++ b/plugins/athena-notes/skills/issue-work/references/repo-resolution.md
@@ -110,7 +110,7 @@ Rules:
   ```
 
 - All `git fetch`, dirty-tree checks, and default-branch lookups should happen against the trunk.
-- The `EnterWorktree` tool handles actual worktree creation; pass it the trunk path, the desired worktree name, and the base branch.
+- `EnterWorktree` only switches the session into an existing worktree (`name` or `path`); it does **not** accept a base branch. Worktree creation goes through `git -C "{TRUNK_ROOT}" worktree add -b {branch} {path} origin/{DEFAULT_BRANCH}` first, then `EnterWorktree(path: ...)` to switch in. See `issue-work` Phase 1.6.
 
 ---
 


### PR DESCRIPTION
## Summary

`issue-work` Phase 1.6 instructed the LLM to call `EnterWorktree` with a `base_branch` parameter that doesn't exist on the tool. Result: every worktree created by `/issue-work` branched off the session's current HEAD instead of the default branch — silently wrong whenever the skill was invoked from inside another worktree (the common case in this repo) or from a trunk parked on a feature branch.

This PR rewrites Phase 1.6 to a three-step pattern: resolve `{TRUNK_ROOT}` (now bound explicitly at the end of Phase 1.4), run `git -C "{TRUNK_ROOT}" worktree add -b {branch} {path} "origin/$DEFAULT_BRANCH"` against the trunk, then `EnterWorktree(path: ...)` to switch in. Mirrors the precedent set by [#68](https://github.com/SnowboardTechie/athena-notes/pull/68) and the `{TRUNK_ROOT}` placeholder convention from [#72](https://github.com/SnowboardTechie/athena-notes/pull/72). Adjacent drift fixed alongside: Phase 1.5's two `$TRUNK` shell-var references rename to `{TRUNK_ROOT}` for consistency, and `references/repo-resolution.md:113` corrects its description of `EnterWorktree`'s contract.

## Test plan

- [x] `frontmatter-lint.yml` — runs locally clean (14 agents, 18 skills validated)
- [x] `docs-lint.yml` — relative trailing-slash pattern returns no matches
- [x] `version-check.yml` — `CHANGELOG.md` entry under `[Unreleased] / Fixed`; `plugin.json` version unchanged so non-release path applies
- [ ] **Smoke test (post-merge, per ticket AC):** invoke `/issue-work {ticket}` from inside another worktree, confirm `git log --oneline -1 issue-{N}-{slug}^` resolves to the tip of `origin/main`

Three review passes via `/pr-self-review` (correctness / security / simplicity) ran in pre-pr mode after the initial commit; 8 findings accepted in-loop, 2 pushed back as out-of-scope (kebab-slug path-traversal tightening — threat model is the user's own tickets, `git check-ref-format` rejects `..`-style branch names; 60-char cap truncation under-spec — over-specifying for a non-issue). No critical or major findings outstanding. Full triage record in the state dir's `summary.md`.

Acceptance criteria from #61, all met:

- Phase 1.6 no longer references a non-existent `EnterWorktree` `base_branch` or `branch_name` parameter.
- `{TRUNK_ROOT}` bound explicitly in Phase 1.4 before `git worktree add` runs.
- Default branch pinned via `origin/\$DEFAULT_BRANCH`.
- Resume case documented in Phase 1.6 + the Edge Cases table row.

## Changelog

- [x] **Non-release PR** — added a bullet under \`## [Unreleased]\` / \`### Fixed\` in \`CHANGELOG.md\`.