### PR TITLE
Release 0.5.0 — core/ groundwork + collaboration lens + auto-ack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Athena Notes are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-05-03
+
 ### Fixed
 - `archivist` agent — resolves the trunk root via `git rev-parse --path-format=absolute --git-common-dir` before searching, so `.notes/` lookups succeed when the agent is invoked from a worktree. Resolves [#59](https://github.com/SnowboardTechie/athena-notes/issues/59).
 - `archivist` agent — vault-existence error path now specifies a `Glob` check rather than leaving the verification mechanism implicit; placeholder syntax switched from `$TRUNK_ROOT` to `{TRUNK_ROOT}` to match `agent-workspace`. Follow-up to [#59](https://github.com/SnowboardTechie/athena-notes/issues/59).
@@ -125,7 +127,8 @@ First public release. Complete port from the OpenCode/OhMyOpenAgent implementati
 ### Removed
 - `PORTING.md` — internal tracker from the OpenCode → Claude Code port. The port is done; the file was stale (GitHub repo already exists, "remaining" items all landed). Historical context preserved in git history.
 
-[Unreleased]: https://github.com/SnowboardTechie/athena-notes/compare/v0.4.3...HEAD
+[Unreleased]: https://github.com/SnowboardTechie/athena-notes/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.5.0
 [0.4.3]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.4.3
 [0.4.2]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.4.2
 [0.4.1]: https://github.com/SnowboardTechie/athena-notes/releases/tag/v0.4.1

--- a/plugins/athena-notes/.claude-plugin/plugin.json
+++ b/plugins/athena-notes/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "athena-notes",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Obsidian-native thinking and note-capture system. A hub-spoke of Claude Code agents (athena, scribe, archivist, sage, forge, and more) that captures your thinking into Obsidian vaults with zero setup friction.",
   "author": {
     "name": "Bryan Thompson"


### PR DESCRIPTION
## Summary

Cuts `0.5.0` from the work on `main` since `0.4.3`. Promotes the `[Unreleased]` block under `## [0.5.0] — 2026-05-03`, bumps `plugins/athena-notes/.claude-plugin/plugin.json` to `0.5.0`, and updates the footer-link block to add `[0.5.0]` and retarget `[Unreleased]` to `compare/v0.5.0...HEAD`.

Highlights:
- `core/` directory established ([#14](https://github.com/SnowboardTechie/athena-notes/issues/14) — host-agnostic / host-specific boundary; groundwork for the host-portability epic)
- `session-review` collaboration lens ([#13](https://github.com/SnowboardTechie/athena-notes/issues/13))
- `pr-self-review` auto-ack on accept-without-diff + source-issue exception to `related_issue` pre-skip ([#62](https://github.com/SnowboardTechie/athena-notes/issues/62))
- `issue-create` parent-issue linking ([#47](https://github.com/SnowboardTechie/athena-notes/issues/47)) + open-questions resolution pass ([#70](https://github.com/SnowboardTechie/athena-notes/issues/70))
- `archivist` worktree-aware vault search ([#59](https://github.com/SnowboardTechie/athena-notes/issues/59))
- `issue-work` Phase 1.6 worktree branches off `origin/$DEFAULT_BRANCH` ([#61](https://github.com/SnowboardTechie/athena-notes/issues/61))
- `workday-planning` Phase 8 persistence receipt ([#30](https://github.com/SnowboardTechie/athena-notes/issues/30))
- `AGENTS.md` sibling-skill preference rule

## Test plan

- [x] `python3 scripts/lint-frontmatter.py` — clean (14 agents, 18 skills).
- [x] `docs-lint` (relative trailing-slash links) — clean.
- [x] CHANGELOG `[Unreleased]` retains an empty section above `[0.5.0]`; footer links validated against the existing pattern.

## Changelog

- [x] **Release PR (`v0.5.0`)** — bumped `plugins/athena-notes/.claude-plugin/plugin.json`, promoted `[Unreleased]` under `## [0.5.0] — 2026-05-03`, added the `[0.5.0]: .../releases/tag/v0.5.0` footer, and retargeted `[Unreleased]` to `compare/v0.5.0...HEAD`.
  - [ ] **After merge:** `gh release create v0.5.0 --target <merge-sha> --title "v0.5.0 — core/ + collaboration lens + auto-ack"` — otherwise the footer link 404s.